### PR TITLE
Fixing bug in dataclass EventSubscriptionOptions

### DIFF
--- a/src/driftpy/events/types.py
+++ b/src/driftpy/events/types.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from abc import abstractmethod
 from solana.transaction import Signature
 from solana.rpc.commitment import Commitment, Confirmed
@@ -139,7 +139,7 @@ class EventSubscriptionOptions:
     order_dir: EventSubscriptionOrderDirection = "asc"
     commitment: Commitment = "confirmed"
     max_tx: int = 4096
-    log_provider_config: LogProviderConfig = WebsocketLogProviderConfig()
+    log_provider_config: LogProviderConfig = field(default_factory=WebsocketLogProviderConfig)
     until_tx: Signature = None
 
     @staticmethod


### PR DESCRIPTION
Bug: #ValueError: mutable default <class 'LogProviderConfig'> for field is not allowed: use default_factory
Fix: using default_factory now