### PR TITLE
Allows for the Jupiter V6 Swap API url to be configured

### DIFF
--- a/docs/clearing_house.md
+++ b/docs/clearing_house.md
@@ -22,6 +22,6 @@ await drift_client.add_liquidity(
 
 ## Configuration
 
-Use the `JUPITER_URL` environment variable to set the endpoint URL for the Jupiter V6 Swap API. This allows you to switch between self-hosted, paid-hosted, or other public API endpoints such as jupiterapi.com for improved rate limits and reduced latency. For more details, see the official [self-hosted](https://station.jup.ag/docs/apis/self-hosted) and [paid-hosted](https://station.jup.ag/docs/apis/self-hosted#paid-hosted-apis) documentation.
+Use the `JUPITER_URL` environment variable to set the endpoint URL for the Jupiter V6 Swap API. This allows you to switch between self-hosted, paid-hosted, or other public API endpoints such as [jupiterapi.com](https://www.jupiterapi.com/) for higher rate limits and reduced latency. For more details, see the official [self-hosted](https://station.jup.ag/docs/apis/self-hosted) and [paid-hosted](https://station.jup.ag/docs/apis/self-hosted#paid-hosted-apis) documentation.
 
 :::driftpy.drift_client

--- a/docs/clearing_house.md
+++ b/docs/clearing_house.md
@@ -20,4 +20,8 @@ await drift_client.add_liquidity(
 )
 ```
 
+## Configuration
+
+Use the `JUPITER_URL` environment variable to set the endpoint URL for the Jupiter V6 Swap API. This allows you to switch between self-hosted, paid-hosted, or other public API endpoints such as jupiterapi.com for improved rate limits and reduced latency. For more details, see the official [self-hosted](https://station.jup.ag/docs/apis/self-hosted) and [paid-hosted](https://station.jup.ag/docs/apis/self-hosted#paid-hosted-apis) documentation.
+
 :::driftpy.drift_client

--- a/src/driftpy/drift_client.py
+++ b/src/driftpy/drift_client.py
@@ -1,4 +1,5 @@
 import json
+import os
 from deprecated import deprecated
 import requests
 from solders.pubkey import Pubkey
@@ -2524,7 +2525,7 @@ class DriftClient:
         user_account_public_key: Optional[Pubkey] = None,
     ) -> Tuple[list[Instruction], list[AddressLookupTableAccount]]:
         pre_instructions: list[Instruction] = []
-        JUPITER_URL = "https://quote-api.jup.ag/v6"
+        JUPITER_URL = os.getenv('JUPITER_URL', "https://quote-api.jup.ag/v6")
 
         out_market = self.get_spot_market_account(out_market_idx)
         in_market = self.get_spot_market_account(in_market_idx)


### PR DESCRIPTION
Allows for the Jupiter V6 Swap API url to be configured via an environment variable while defaulting to the original hardcoded value and document the use of it. This should be helpful for cases where customers run into rate limits with the public API or are looking for lower latency with self/paid hosted installations.