### PR TITLE
Cleanup: remove unnecessary print statement

### DIFF
--- a/src/driftpy/decode/pull_oracle.py
+++ b/src/driftpy/decode/pull_oracle.py
@@ -12,7 +12,6 @@ def decode_pull_oracle(buffer: bytes) -> PriceUpdateV2:
     offset += 32  # skip write_authority
 
     verification_level_flag = read_uint8(buffer, offset)
-    print(verification_level_flag)
     if verification_level_flag & 0x1:
         offset += 1  # skip verification_level Full
     else:


### PR DESCRIPTION
Removed the print statement from `src/driftpy/decode/pull_oracle.py`
line no. 15 link - https://github.com/drift-labs/driftpy/blob/97d24d81c1937cbd0dd75ff19787a56fd6348e0d/src/driftpy/decode/pull_oracle.py#L15