### PR TITLE
USDC deposits do not work: wrong `close_account` call and `UnboundLocalError: local variable 'ata_pubkey' referenced before assignment`

### DIFF
--- a/src/driftpy/drift_client.py
+++ b/src/driftpy/drift_client.py
@@ -1019,14 +1019,15 @@ class DriftClient:
             ),
         )
         instructions.append(deposit_ix)
-        close_account_params = CloseAccountParams(
-            program_id=TOKEN_PROGRAM_ID,
-            account=ata_pubkey,
-            dest=signer_authority,
-            owner=signer_authority,
-        )
-        close_account_ix = close_account(close_account_params)
-        instructions.append(close_account_ix)
+        if create_WSOL_token_account:
+            close_account_params = CloseAccountParams(
+                program_id=TOKEN_PROGRAM_ID,
+                account=user_token_account,
+                dest=signer_authority,
+                owner=signer_authority,
+            )
+            close_account_ix = close_account(close_account_params)
+            instructions.append(close_account_ix)
         return instructions
 
     async def withdraw(


### PR DESCRIPTION
Comparing TS SDK deposit with Python SDK deposits reveals a problem with `close_account` call when trying to deposit something different from WSOL, e.g. USDC deposit.

First, this line uses `ata_pubkey` that might not be initialized:

https://github.com/drift-labs/driftpy/blob/961676c5aa31c85139ced04a516787ce193cb7ef/src/driftpy/drift_client.py#L1024

which results in:
```
UnboundLocalError: local variable 'ata_pubkey' referenced before assignment
```

The reason is that only get initilized here

https://github.com/drift-labs/driftpy/blob/961676c5aa31c85139ced04a516787ce193cb7ef/src/driftpy/drift_client.py#L986

Instead of ata_pubkey , user_token_account should be used as it happens in TS SDK.

Second, similar to TS sdk we need to check `create_WSOL_token_account` before adding close instruction to the transaction:

```
        if create_WSOL_token_account:
            close_account_params = CloseAccountParams(
                program_id=TOKEN_PROGRAM_ID,
                account=user_token_account,
                dest=signer_authority,
                owner=signer_authority,
            )
            close_account_ix = close_account(close_account_params)
            instructions.append(close_account_ix)
```