### PR TITLE
Add new scripts for authority user account lookup, enhanced user map, and market map details

### DIFF
--- a/examples/authority_user-account_lookup.py
+++ b/examples/authority_user-account_lookup.py
@@ -1,0 +1,216 @@
+# Import required libraries
+# asyncio for asynchronous programming
+import asyncio
+# os for interacting with the operating system, particularly for environment variables
+import os
+# csv for handling CSV file operations
+import csv
+# datetime for generating timestamps
+from datetime import datetime
+
+# Importing necessary classes from the Anchor and Solana libraries
+from anchorpy import Wallet
+from dotenv import load_dotenv  # For loading environment variables from a .env file
+from solana.rpc.async_api import AsyncClient  # Asynchronous client for Solana RPC
+
+# Importing classes from the Drift protocol library
+from driftpy.drift_client import DriftClient  # Client to interact with the Drift protocol
+from driftpy.user_map.user_map import UserMap  # Class to manage user states in Drift
+from driftpy.user_map.user_map_config import UserMapConfig  # Configuration for UserMap
+from driftpy.user_map.user_map_config import (
+    WebsocketConfig as UserMapWebsocketConfig,  # Websocket configuration for UserMap
+)
+
+async def get_user_map():
+    """Initialize and return the UserMap instance."""
+    # Load environment variables and get RPC URL
+    load_dotenv()
+    url = os.getenv("RPC_URL")
+    
+    if not url:
+        raise ValueError("RPC_URL not found in environment variables. Please check your .env file.")
+    
+    try:
+        # Initialize connection and drift client
+        connection = AsyncClient(url, timeout=30)
+        await connection.is_connected()
+        
+        dc = DriftClient(
+            connection,
+            Wallet.dummy(),
+            "mainnet",
+        )
+        await dc.subscribe()
+        
+        # Initialize and subscribe to UserMap
+        user_map = UserMap(UserMapConfig(dc, UserMapWebsocketConfig()))
+        await user_map.subscribe()
+        
+        return user_map
+    
+    except Exception as e:
+        print(f"Error initializing connection: {str(e)}")
+        raise
+
+def normalize_authority(authority):
+    """Normalize authority string for consistent comparison."""
+    if not authority:
+        return ""
+    authority_str = str(authority)
+    # Remove any whitespace and convert to lowercase
+    return authority_str.strip().lower()
+
+def load_authorities_from_csv(filename):
+    """
+    Load top 200 authorities from the fuel breakdown CSV file,
+    sorted by depositFuel in descending order.
+    """
+    authority_data = []
+    try:
+        with open(filename, 'r') as csvfile:
+            reader = csv.DictReader(csvfile)
+            # Verify that required columns exist
+            required_columns = ['authority', 'depositFuel']
+            if not all(col in reader.fieldnames for col in required_columns):
+                raise ValueError("CSV file must contain both 'authority' and 'depositFuel' columns")
+            
+            # Extract authority and depositFuel, converting depositFuel to float
+            for row in reader:
+                if row['authority'] and row['depositFuel']:  # Only add non-empty entries
+                    try:
+                        deposit_fuel = float(row['depositFuel'])
+                        authority_data.append({
+                            'authority': normalize_authority(row['authority']),  # Normalized
+                            'depositFuel': deposit_fuel,
+                            'original_authority': row['authority']  # Keep original for output
+                        })
+                    except ValueError:
+                        print(f"Warning: Invalid depositFuel value for authority {row['authority']}, skipping")
+                        continue
+        
+        # Sort by depositFuel in descending order and take top 200
+        sorted_authorities = sorted(authority_data, key=lambda x: x['depositFuel'], reverse=True)[:200]
+        
+        # Create a list of tuples with normalized and original authorities
+        top_200_authorities = [(item['authority'], item['original_authority']) for item in sorted_authorities]
+        
+        print(f"Successfully loaded top 200 authorities from {filename}, sorted by depositFuel")
+        return top_200_authorities
+    
+    except FileNotFoundError:
+        print(f"Error: Could not find CSV file at {filename}")
+        raise
+    except ValueError as ve:
+        print(f"Error with CSV format: {str(ve)}")
+        raise
+    except Exception as e:
+        print(f"Error reading authorities from CSV: {str(e)}")
+        raise
+
+async def lookup_user_accounts(authorities):
+    """
+    Look up user accounts for given authorities.
+    
+    Args:
+        authorities (list): List of authority addresses to look up
+        
+    Returns:
+        list: List of dictionaries containing authority and associated user accounts
+    """
+    try:
+        # Get UserMap instance
+        print("Initializing UserMap...")
+        user_map = await get_user_map()
+        
+        # Normalize input authorities
+        normalized_authorities = [(normalize_authority(auth), auth) for auth in authorities]
+        
+        # Create results list to store authority-user mappings
+        results = []
+        total_authorities = len(normalized_authorities)
+        
+        # Build authority lookup map for efficient processing
+        print("\nBuilding authority lookup map...")
+        authority_lookup = {}
+        skipped_count = 0
+        for user_key, user in user_map.user_map.items():
+            try:
+                auth = user_map.get_user_authority(user_key)
+                if auth:
+                    norm_auth = normalize_authority(auth)
+                    if norm_auth not in authority_lookup:
+                        authority_lookup[norm_auth] = []
+                    authority_lookup[norm_auth].append(str(user_key))
+            except Exception as e:
+                skipped_count += 1
+                print(f"Warning: Skipped user {str(user_key)[:8]}... due to: {str(e)}")
+                continue
+        
+        if skipped_count > 0:
+            print(f"Warning: Skipped {skipped_count} users while building lookup map")
+        
+        # Process each authority
+        print("\nProcessing authorities...")
+        for idx, (norm_authority, orig_authority) in enumerate(normalized_authorities, 1):
+            print(f"Processing {idx}/{total_authorities}: {orig_authority[:8]}...")
+            try:
+                found_users = authority_lookup.get(norm_authority, [])
+                
+                if found_users:
+                    for user_account in found_users:
+                        results.append({
+                            'authority': orig_authority,
+                            'user_account': user_account
+                        })
+                    print(f"  ✓ Found {len(found_users)} user account(s).")
+                else:
+                    results.append({
+                        'authority': orig_authority,
+                        'user_account': 'No user accounts found'
+                    })
+                    print(f"  - No user accounts found")
+            
+            except Exception as e:
+                print(f"  ✗ Error processing authority: {str(e)}")
+                results.append({
+                    'authority': orig_authority,
+                    'user_account': f'Error processing authority: {str(e)}'
+                })
+        
+        # Print summary statistics
+        print("\nProcessing complete!")
+        authorities_with_matches = sum(
+            1 
+            for r in results 
+            if r['user_account'] != 'No user accounts found'
+        )
+        print(f"Found matches for {authorities_with_matches} out of {total_authorities} authorities")
+        
+        return results
+        
+    except Exception as e:
+        print(f"Error in lookup execution: {str(e)}")
+        raise
+
+async def main():
+    """
+    Example usage of the lookup_user_accounts function.
+    Replace the example authorities with actual ones you want to look up.
+    """
+    # Example authorities to look up
+    example_authorities = [
+        "FULqR3GHUtHBxjhVHRSg7u1JXvBxQNPZGS9fnhqt8YEk",
+        "8SSLjXBR1acDjvKjJsGGWEhMoMHwvPxiJx9uoGQsDUNo"
+    ]
+    
+    results = await lookup_user_accounts(example_authorities)
+    return results
+
+if __name__ == "__main__":
+    try:
+        print("\n=== Authority to User Account Lookup ===\n")
+        results = asyncio.run(main())
+        print("\n=== Processing Complete ===\n")
+        
+    except Exception as e:
+        print(f"\n✗ Fatal error: {str(e)}")

--- a/examples/driftpy-enhanced-usermap.py
+++ b/examples/driftpy-enhanced-usermap.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+"""
+Drift Protocol Position and Balance Query Tool
+
+This script provides a comprehensive view of user positions and balances on the Drift Protocol.
+It can query information using either a user's authority address or a specific user account address.
+
+Features:
+- Display account summary including health, collateral, and leverage
+- Show active perpetual positions with market details and PnL
+- Show active spot positions with deposit/borrow information
+- Display LP (Liquidity Provider) positions and shares
+- Real-time market data including oracle prices and AMM state
+
+Requirements:
+- Python 3.7+
+- Required environment variables:
+  * RPC_URL: Solana RPC endpoint URL
+  OR
+  * Use --rpc command line argument to specify RPC URL directly
+
+Usage Examples:
+    # Query by authority address
+    ./driftpy-enhanced-usermap.py --authority <AUTHORITY_PUBKEY>
+
+    # Query by specific user account
+    ./driftpy-enhanced-usermap.py --account <USER_ACCOUNT_PUBKEY>
+
+    # Use custom RPC endpoint
+    ./driftpy-enhanced-usermap.py --authority <PUBKEY> --rpc <RPC_URL>
+"""
+
+import os
+import asyncio
+import argparse
+from typing import Optional, List, Dict, Any
+from dataclasses import dataclass
+
+from anchorpy import Wallet
+from dotenv import load_dotenv
+from solders.pubkey import Pubkey # type: ignore
+from solana.rpc.async_api import AsyncClient
+
+from driftpy.drift_client import DriftClient
+from driftpy.drift_user import DriftUser
+from driftpy.accounts import DataAndSlot, UserAccount
+from driftpy.user_map.user_map import UserMap
+from driftpy.user_map.user_map_config import UserMapConfig, PollingConfig
+from driftpy.constants.numeric_constants import QUOTE_SPOT_MARKET_INDEX
+from driftpy.types import SpotPosition, PerpPosition, MarketType
+from driftpy.keypair import load_keypair
+from driftpy.market_map.market_map import MarketMap
+from driftpy.market_map.market_map_config import MarketMapConfig, WebsocketConfig
+
+# Load environment variables
+load_dotenv()
+
+@dataclass
+class FormattedPosition:
+    """Formatted position for better readability"""
+    market_index: int
+    market_name: str
+    market_type: str
+    position_size: float
+    position_value: float
+    entry_price: Optional[float] = None
+    pnl: Optional[float] = None
+    funding_pnl: Optional[float] = None
+    lp_shares: Optional[float] = None
+    last_base_asset_amount_per_lp: Optional[float] = None
+
+def format_number(number: float, decimals: int = 2, use_commas: bool = True) -> str:
+    """Format a number with proper decimal places and optional comma separators"""
+    if abs(number) >= 1e6:
+        # For large numbers, use millions format
+        return f"{number/1e6:,.{decimals}f}M"
+    elif abs(number) >= 1e3 and use_commas:
+        return f"{number:,.{decimals}f}"
+    else:
+        return f"{number:.{decimals}f}"
+
+class EnhancedUserMap:
+    """Enhanced UserMap class for accessing and displaying user positions and balances"""
+    
+    def __init__(self, connection, wallet):
+        """Initialize with connection and wallet"""
+        self.connection = connection
+        self.wallet = wallet
+        self.drift_client = DriftClient(connection, wallet)
+        self.user_map = None
+    
+    async def initialize(self):
+        """Initialize the drift client and market map"""
+        await self.drift_client.subscribe()
+        self.user_map = UserMap(
+            UserMapConfig(
+                self.drift_client,
+                PollingConfig(frequency=10000),  # Polling frequency in ms
+                self.connection,
+                include_idle=True,  # Include idle accounts
+            )
+        )
+        await self.user_map.subscribe()
+        
+    async def cleanup(self):
+        """Clean up connections"""
+        if self.user_map:
+            await self.user_map.unsubscribe()
+        await self.drift_client.unsubscribe()
+    
+    async def get_user_by_authority(self, authority_pubkey: Pubkey) -> List[DriftUser]:
+        """Get all user accounts associated with an authority"""
+        if not self.user_map:
+            raise ValueError("UserMap not initialized")
+        
+        users = []
+        
+        # Sync the user map to fetch all accounts
+        await self.user_map.sync()
+        
+        # Find all accounts with matching authority
+        for user in self.user_map.values():
+            try:
+                user_authority = user.get_user_account().authority
+                if str(user_authority) == str(authority_pubkey):
+                    users.append(user)
+            except Exception as e:
+                print(f"Error checking user authority: {e}")
+        
+        return users
+    
+    async def get_user_by_account(self, user_account_pubkey: Pubkey) -> Optional[DriftUser]:
+        """Get a specific user account by its address"""
+        if not self.user_map:
+            raise ValueError("UserMap not initialized")
+        
+        # Sync the user map to fetch all accounts
+        await self.user_map.sync()
+        
+        # Find the specific user account
+        return self.user_map.get(str(user_account_pubkey))
+    
+    def format_perp_position(self, user: DriftUser, position: PerpPosition) -> FormattedPosition:
+        """Format a perpetual position for display"""
+        market = self.drift_client.get_perp_market_account(position.market_index)
+        oracle_price_data = user.get_oracle_data_for_perp_market(position.market_index)
+        
+        # Decode market name from bytes
+        market_name = bytes(market.name).decode('utf-8').strip('\x00')
+        
+        # Get position value in USD
+        position_value = user.get_perp_position_value(
+            position.market_index, 
+            oracle_price_data,
+            include_open_orders=True
+        )
+        
+        # Calculate base asset amount with precision adjustment
+        base_asset_amount = position.base_asset_amount / 1e9  # BASE_PRECISION
+        
+        # Calculate entry price if possible
+        entry_price = None
+        if position.base_asset_amount != 0:
+            entry_price = abs(position.quote_entry_amount / position.base_asset_amount * 1e9)
+        
+        # Calculate unrealized PnL
+        unrealized_pnl = user.get_unrealized_pnl(
+            with_funding=False,
+            market_index=position.market_index
+        ) / 1e6  # QUOTE_PRECISION
+        
+        # Calculate funding PnL
+        funding_pnl = user.get_unrealized_funding_pnl(
+            market_index=position.market_index
+        ) / 1e6  # QUOTE_PRECISION
+
+        # Get LP information
+        lp_shares = position.lp_shares / 1e9 if position.lp_shares != 0 else 0
+        last_base_per_lp = position.last_base_asset_amount_per_lp / 1e9 if position.last_base_asset_amount_per_lp != 0 else 0
+        
+        return FormattedPosition(
+            market_index=position.market_index,
+            market_name=market_name,
+            market_type="Perpetual",
+            position_size=base_asset_amount,
+            position_value=position_value / 1e6,  # QUOTE_PRECISION
+            entry_price=entry_price,
+            pnl=unrealized_pnl,
+            funding_pnl=funding_pnl,
+            lp_shares=lp_shares,
+            last_base_asset_amount_per_lp=last_base_per_lp
+        )
+    
+    def format_spot_position(self, user: DriftUser, position: SpotPosition) -> FormattedPosition:
+        """Format a spot market position for display"""
+        market = self.drift_client.get_spot_market_account(position.market_index)
+        oracle_price_data = user.get_oracle_data_for_spot_market(position.market_index)
+        
+        # Decode market name from bytes
+        market_name = bytes(market.name).decode('utf-8').strip('\x00')
+        
+        # Get token amount with proper sign (positive for deposits, negative for borrows)
+        token_amount = user.get_token_amount(position.market_index)
+        
+        # Convert to human readable format based on decimals
+        decimals = market.decimals
+        formatted_token_amount = token_amount / (10 ** decimals)
+        
+        # Calculate token value in USD
+        token_value = 0
+        if position.market_index == QUOTE_SPOT_MARKET_INDEX:
+            # For USDC, the value is just the token amount
+            token_value = abs(formatted_token_amount)
+        else:
+            # For other tokens, calculate USD value
+            base_value = user.get_spot_market_asset_value(
+                market_index=position.market_index,
+                include_open_orders=True
+            ) / 1e6  # QUOTE_PRECISION
+            if token_amount < 0:
+                liability_value = user.get_spot_market_liability_value(
+                    market_index=position.market_index,
+                    include_open_orders=True
+                ) / 1e6  # QUOTE_PRECISION
+                token_value = liability_value
+            else:
+                token_value = base_value
+        
+        return FormattedPosition(
+            market_index=position.market_index,
+            market_name=market_name,
+            market_type="Spot",
+            position_size=formatted_token_amount,
+            position_value=token_value
+        )
+    
+    async def get_formatted_positions(self, user: DriftUser) -> Dict[str, List[FormattedPosition]]:
+        """Get formatted positions for a user"""
+        result = {
+            "perp_positions": [],
+            "spot_positions": []
+        }
+        
+        # Get active perpetual positions
+        perp_positions = user.get_active_perp_positions()
+        for position in perp_positions:
+            formatted = self.format_perp_position(user, position)
+            result["perp_positions"].append(formatted)
+        
+        # Get active spot positions
+        spot_positions = user.get_active_spot_positions()
+        for position in spot_positions:
+            formatted = self.format_spot_position(user, position)
+            result["spot_positions"].append(formatted)
+        
+        return result
+    
+    async def get_account_summary(self, user: DriftUser) -> Dict[str, Any]:
+        """Get summary information about the user account"""
+        user_account = user.get_user_account()
+        
+        # Calculate collateral and margin requirements
+        total_collateral = user.get_total_collateral() / 1e6
+        margin_requirement = user.get_margin_requirement() / 1e6
+        free_collateral = user.get_free_collateral() / 1e6
+        
+        # Get health info
+        health = user.get_health()
+        
+        # Get leverage
+        leverage = user.get_leverage() / 10000  # Convert from basis points to x format
+        
+        # Get authority's pubkey as string
+        authority = str(user_account.authority)
+        
+        # Get subaccount id
+        subaccount_id = user_account.sub_account_id
+        
+        # Get settled PnL
+        settled_pnl = user.get_settled_perp_pnl() / 1e6
+        
+        # Get account value
+        net_usd_value = user.get_net_usd_value() / 1e6
+        
+        return {
+            "authority": authority,
+            "sub_account_id": subaccount_id,
+            "account_health": health,
+            "total_collateral": total_collateral,
+            "margin_requirement": margin_requirement,
+            "free_collateral": free_collateral,
+            "leverage": leverage,
+            "settled_pnl": settled_pnl,
+            "net_usd_value": net_usd_value
+        }
+
+def print_summary(summary: Dict[str, Any]):
+    """
+    Print a formatted summary of the user account.
+    
+    Args:
+        summary: Dictionary containing account summary information including:
+            - authority: Authority public key
+            - sub_account_id: Sub-account identifier
+            - account_health: Health percentage
+            - total_collateral: Total collateral in USD
+            - margin_requirement: Required margin in USD
+            - free_collateral: Available collateral in USD
+            - leverage: Current account leverage
+            - settled_pnl: Settled PnL in USD
+            - net_usd_value: Net account value in USD
+    """
+    print("\n=== Account Summary ===")
+    print(f"Authority: {summary['authority']}")
+    print(f"Sub Account ID: {summary['sub_account_id']}")
+    print(f"Account Health: {summary['account_health']}%")
+    print(f"Total Collateral: ${format_number(summary['total_collateral'])}")
+    print(f"Margin Requirement: ${format_number(summary['margin_requirement'])}")
+    print(f"Free Collateral: ${format_number(summary['free_collateral'])}")
+    print(f"Leverage: {format_number(summary['leverage'], 2, False)}x")
+    print(f"Settled PnL: ${format_number(summary['settled_pnl'])}")
+    print(f"Net USD Value: ${format_number(summary['net_usd_value'])}")
+
+def print_positions(positions: Dict[str, List[FormattedPosition]], drift_client: DriftClient):
+    """
+    Print formatted position information for both spot and perpetual markets.
+    
+    Args:
+        positions: Dictionary containing lists of spot and perpetual positions
+        drift_client: DriftClient instance for fetching market data
+    
+    Displays:
+        For Spot Positions:
+        - Market name and index
+        - Position type (Deposit/Borrow)
+        - Size and USD value
+        - Market status and asset information
+        - Total deposits and borrows
+        
+        For Perpetual Positions:
+        - Market name and index
+        - Position type (Long/Short)
+        - Size, entry price, and USD value
+        - Unrealized PnL and funding PnL
+        - Market status and contract information
+        - AMM state and LP information if applicable
+    """
+    # Print spot positions
+    if positions["spot_positions"]:
+        print("\n=== Spot Positions ===")
+        for pos in positions["spot_positions"]:
+            try:
+                position_type = "Deposit" if pos.position_size > 0 else "Borrow"
+                market = drift_client.get_spot_market_account(pos.market_index)
+                
+                print(f"Market: {pos.market_name} (Index: {pos.market_index})")
+                print(f"Type: {position_type}")
+                print(f"Size: {format_number(abs(pos.position_size), 6, False)}")
+                print(f"Value: ${format_number(abs(pos.position_value))}")
+                
+                # Display market info if available
+                if market:
+                    print(f"Market Status: {market.status.__class__.__name__}")
+                    print(f"Asset Tier: {market.asset_tier.__class__.__name__}")
+                    print(f"Oracle Source: {market.oracle_source.__class__.__name__}")
+                    print(f"Total Deposits: {format_number(market.deposit_balance / (10 ** market.decimals))}")
+                    print(f"Total Borrows: {format_number(market.borrow_balance / (10 ** market.decimals))}")
+            except Exception as e:
+                print(f"Warning: Could not fetch complete market data: {str(e)}")
+            print("---")
+    else:
+        print("\nNo spot positions found.")
+    
+    # Print perpetual positions
+    if positions["perp_positions"]:
+        print("\n=== Perpetual Positions ===")
+        for pos in positions["perp_positions"]:
+            try:
+                position_type = "Long" if pos.position_size > 0 else "Short"
+                market = drift_client.get_perp_market_account(pos.market_index)
+                
+                print(f"Market: {pos.market_name} (Index: {pos.market_index})")
+                print(f"Type: {position_type}")
+                print(f"Size: {format_number(abs(pos.position_size), 6, False)}")
+                print(f"Entry Price: ${format_number(pos.entry_price)}" if pos.entry_price else "Entry Price: N/A")
+                print(f"Value: ${format_number(abs(pos.position_value))}")
+                print(f"Unrealized PnL: ${format_number(pos.pnl)}")
+                print(f"Funding PnL: ${format_number(pos.funding_pnl)}")
+                
+                # Display market info if available
+                if market:
+                    print(f"Market Status: {market.status.__class__.__name__}")
+                    print(f"Contract Type: {market.contract_type.__class__.__name__}")
+                    print(f"Oracle Source: {market.amm.oracle_source.__class__.__name__}")
+                    print(f"24h Volume: {format_number(market.amm.volume24h / 1e6)}M")
+                    print(f"AMM Base Reserve: {format_number(market.amm.base_asset_reserve / 1e9, 4)}")
+                    print(f"AMM Quote Reserve: {format_number(market.amm.quote_asset_reserve / 1e6, 4)}")
+                    print(f"Total LP Shares: {format_number(market.amm.user_lp_shares / 1e9, 4)}")
+                    if pos.lp_shares and pos.lp_shares > 0:
+                        print(f"Your LP Shares: {format_number(pos.lp_shares, 4)}")
+                        if pos.last_base_asset_amount_per_lp:
+                            print(f"Your LP Base Per Share: {format_number(pos.last_base_asset_amount_per_lp, 4)}")
+            except Exception as e:
+                print(f"Warning: Could not fetch complete market data: {str(e)}")
+            print("---")
+    else:
+        print("\nNo perpetual positions found.")
+
+async def find_and_display_user_data(enhanced_map: EnhancedUserMap, address: str, is_authority: bool):
+    """Find and display user data for given address"""
+    pubkey = Pubkey.from_string(address)
+    
+    users = []
+    if is_authority:
+        users = await enhanced_map.get_user_by_authority(pubkey)
+        if not users:
+            print(f"No accounts found for authority: {address}")
+            return
+        print(f"Found {len(users)} sub-account(s) for authority {address}")
+    else:
+        user = await enhanced_map.get_user_by_account(pubkey)
+        if not user:
+            print(f"No user account found at address: {address}")
+            return
+        users = [user]
+    
+    # Process each user account
+    for i, user in enumerate(users):
+        if len(users) > 1:
+            print(f"\n==== Sub-Account {i} ====")
+        
+        # Get account summary
+        summary = await enhanced_map.get_account_summary(user)
+        print_summary(summary)
+        
+        # Get and display positions
+        positions = await enhanced_map.get_formatted_positions(user)
+        print_positions(positions, enhanced_map.drift_client)
+
+async def main():
+    """
+    Main function to process command line arguments and display user positions.
+    
+    Command Line Arguments:
+        --authority: Authority public key to query all associated accounts
+        --account: Specific user account public key to query
+        --rpc: Optional RPC URL (overrides RPC_URL environment variable)
+    
+    Environment Variables:
+        RPC_URL: Required if --rpc not provided. Solana RPC endpoint URL.
+    
+    The script will:
+    1. Connect to the Drift Protocol
+    2. Query user account(s)
+    3. Display account summary
+    4. Show all active positions with detailed market information
+    """
+    parser = argparse.ArgumentParser(
+        description="Query Drift Protocol for positions and balances",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    # Query by authority address
+    %(prog)s --authority <AUTHORITY_PUBKEY>
+    
+    # Query specific user account
+    %(prog)s --account <USER_ACCOUNT_PUBKEY>
+    
+    # Use custom RPC endpoint
+    %(prog)s --authority <PUBKEY> --rpc <RPC_URL>
+
+Notes:
+    - Either --authority or --account must be provided
+    - RPC URL must be provided either via --rpc or RPC_URL environment variable
+    - For accurate results, ensure the RPC endpoint is reliable and up-to-date
+    """
+    )
+    
+    # Define the arguments
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--authority", help="Authority public key to query")
+    group.add_argument("--account", help="User account public key to query")
+    
+    parser.add_argument("--rpc", help="RPC URL (will use RPC_URL env var if not provided)")
+    
+    # Parse the arguments
+    args = parser.parse_args()
+    
+    # Get RPC URL
+    rpc_url = args.rpc or os.environ.get("RPC_URL")
+    if not rpc_url:
+        print("Error: RPC URL is required. Either set the RPC_URL environment variable or use --rpc")
+        return
+    
+    # Create a dummy keypair - we're only reading data, not signing transactions
+    from solders.keypair import Keypair
+    kp = Keypair()
+    wallet = Wallet(kp)
+    
+    # Setup connection
+    connection = AsyncClient(rpc_url)
+    
+    # Create enhanced user map
+    enhanced_map = EnhancedUserMap(connection, wallet)
+    
+    try:
+        # Initialize
+        await enhanced_map.initialize()
+        
+        if args.authority:
+            await find_and_display_user_data(enhanced_map, args.authority, True)
+        else:  # args.account
+            await find_and_display_user_data(enhanced_map, args.account, False)
+            
+    except Exception as e:
+        print(f"Error: {str(e)}")
+    finally:
+        # Clean up
+        await enhanced_map.cleanup()
+
+if __name__ == "__main__":
+    asyncio.run(main()) 

--- a/examples/driftpy-marketmap-details.py
+++ b/examples/driftpy-marketmap-details.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""
+Drift Protocol Market Explorer
+
+This script provides a comprehensive interface for exploring and inspecting markets on the Drift Protocol.
+It allows users to view and analyze both Perpetual and Spot markets with detailed attribute information.
+
+Features:
+- Lists all available Perpetual and Spot markets
+- Interactive market selection by ID (e.g., 'P0' for Perp markets, 'S1' for Spot markets)
+- Flexible attribute selection:
+  * View all attributes
+  * View basic attributes only
+  * Select specific attributes
+  * Group-based selection
+- Detailed market information including:
+  * Basic market details (name, index, status)
+  * AMM parameters for perpetual markets
+  * Oracle and pricing information
+  * Risk parameters
+  * Insurance fund details
+  * Historical data
+
+Requirements:
+- Python 3.7+
+- Required environment variables:
+  * RPC_URL: Solana RPC endpoint URL
+
+Usage:
+1. Run the script:
+   ```
+   python driftpy-marketmap-details.py
+   ```
+2. Select a market using the format:
+   - 'P0' for Perpetual market index 0
+   - 'S1' for Spot market index 1
+3. Choose attributes to display:
+   - Enter numbers for specific attributes
+   - Type 'all' for all attributes
+   - Type 'basic' for common attributes
+   - Type 'group:amm' for all AMM-related attributes
+
+Notes:
+- The script maintains separate attribute selections for Perpetual and Spot markets
+- You can reuse previous attribute selections for the same market type
+- Market data is fetched in real-time from the Drift Protocol
+"""
+
+# the goal of this script is to show an implementation of the driftpy market map
+# it will show all the markets and allow you to select one to inspect
+
+import os
+import asyncio
+import inspect
+from anchorpy import Wallet
+from dotenv import load_dotenv
+from driftpy.keypair import load_keypair
+from driftpy.drift_client import DriftClient
+from driftpy.market_map.market_map import MarketMap
+from driftpy.market_map.market_map_config import MarketMapConfig, WebsocketConfig
+from driftpy.types import MarketType, ContractType, ContractTier, MarketStatus, OracleSource, AssetTier
+from solana.rpc.async_api import AsyncClient
+from solders.keypair import Keypair # type: ignore
+import base58
+
+load_dotenv()  # load environment variables from .env file
+
+# Generate a random Solana keypair (wallet) for interaction with Drift
+kp = Keypair()
+
+# create a wallet from the keypair
+wallet = Wallet(kp)
+
+# get the rpc url from the environment variable
+connection = AsyncClient(os.environ.get('RPC_URL'))
+
+# create a drift client
+drift_client = DriftClient(connection, wallet)
+
+def format_market_name(name_bytes):
+    """
+    Convert market name bytes to a human-readable string.
+    
+    Args:
+        name_bytes (List[int]): List of bytes representing the market name
+        
+    Returns:
+        str: Decoded and stripped market name string
+    """
+    return bytes(name_bytes).decode('utf-8').strip()
+
+def format_pubkey(pubkey):
+    """
+    Format public key for display by truncating with ellipsis.
+    
+    Args:
+        pubkey (str): Full public key string
+        
+    Returns:
+        str: Truncated public key with ellipsis (e.g., "ABC...XYZ")
+    """
+    return str(pubkey)[:20] + "..."
+
+def format_number(number, decimals=6):
+    """
+    Format large numbers for better readability with proper decimal precision.
+    
+    Args:
+        number (int): Raw number to format (usually in base units)
+        decimals (int, optional): Number of decimal places to use. Defaults to 6.
+        
+    Returns:
+        str: Formatted number string with commas and proper decimal places
+    """
+    return f"{number / (10 ** decimals):,.6f}"
+
+def get_perp_market_attributes():
+    """
+    Get all available attributes for perpetual markets.
+    
+    This function returns a comprehensive list of attribute paths that can be accessed
+    on a PerpMarketAccount object. The attributes are organized into categories:
+    - Base attributes (market details, status, risk parameters)
+    - AMM attributes (oracle, reserves, funding rates)
+    - Insurance claim attributes
+    
+    Returns:
+        List[str]: List of attribute paths that can be accessed on a PerpMarketAccount
+    """
+    # Base attributes directly on PerpMarketAccount
+    base_attrs = [
+        "pubkey", "market_index", "name",
+        "status", "contract_type", "contract_tier",
+        "margin_ratio_initial", "margin_ratio_maintenance",
+        "imf_factor", "unrealized_pnl_imf_factor", 
+        "liquidator_fee", "if_liquidation_fee",
+        "unrealized_pnl_initial_asset_weight", "unrealized_pnl_maintenance_asset_weight",
+        "number_of_users", "number_of_users_with_base",
+        "quote_spot_market_index", "fee_adjustment",
+        "paused_operations", "expiry_ts", "expiry_price",
+    ]
+    
+    # AMM attributes
+    amm_attrs = [
+        "amm.oracle", "amm.base_asset_reserve", "amm.quote_asset_reserve",
+        "amm.sqrt_k", "amm.peg_multiplier", "amm.base_asset_amount_long",
+        "amm.base_asset_amount_short", "amm.base_asset_amount_with_amm",
+        "amm.last_funding_rate", "amm.last_funding_rate_ts", "amm.funding_period",
+        "amm.order_step_size", "amm.order_tick_size", "amm.min_order_size",
+        "amm.max_position_size", "amm.volume24h", "amm.oracle_source",
+        "amm.last_oracle_valid", "amm.base_spread", "amm.max_spread",
+    ]
+    
+    # Insurance claim attributes
+    insurance_attrs = [
+        "insurance_claim.quote_max_insurance", "insurance_claim.quote_settled_insurance",
+    ]
+    
+    return base_attrs + amm_attrs + insurance_attrs
+
+def get_spot_market_attributes():
+    """
+    Get all available attributes for spot markets.
+    
+    This function returns a comprehensive list of attribute paths that can be accessed
+    on a SpotMarketAccount object. The attributes are organized into categories:
+    - Base attributes (market details, status, risk parameters)
+    - Interest rate attributes
+    - Historical oracle data attributes
+    - Insurance fund attributes
+    
+    Returns:
+        List[str]: List of attribute paths that can be accessed on a SpotMarketAccount
+    """
+    # Base attributes directly on SpotMarketAccount
+    base_attrs = [
+        "pubkey", "oracle", "mint", "vault", "name", "market_index",
+        "status", "asset_tier", "oracle_source", "decimals",
+        "initial_asset_weight", "maintenance_asset_weight",
+        "initial_liability_weight", "maintenance_liability_weight",
+        "imf_factor", "liquidator_fee", "if_liquidation_fee",
+        "deposit_balance", "borrow_balance", "total_spot_fee",
+        "total_social_loss", "total_quote_social_loss",
+        "withdraw_guard_threshold", "max_token_deposits",
+        "order_step_size", "order_tick_size", "min_order_size", "max_position_size",
+    ]
+    
+    # Interest rate attributes
+    interest_attrs = [
+        "optimal_utilization", "optimal_borrow_rate", "max_borrow_rate",
+        "deposit_token_twap", "borrow_token_twap", "utilization_twap",
+    ]
+    
+    # Historical oracle data attributes
+    oracle_attrs = [
+        "historical_oracle_data.last_oracle_price", 
+        "historical_oracle_data.last_oracle_conf",
+        "historical_oracle_data.last_oracle_price_twap",
+    ]
+    
+    # Insurance fund attributes
+    insurance_attrs = [
+        "insurance_fund.total_shares", "insurance_fund.user_shares",
+    ]
+    
+    return base_attrs + interest_attrs + oracle_attrs + insurance_attrs
+
+def display_nested_attribute(obj, attr_path, indent=0):
+    """
+    Display a nested attribute value with proper formatting based on its type and context.
+    
+    This function handles various types of attributes including:
+    - Market names (byte arrays)
+    - Public keys (truncated display)
+    - Numeric values (proper decimal formatting)
+    - Enum values (class name display)
+    - Nested object attributes
+    
+    Args:
+        obj: The object containing the attribute
+        attr_path (str): Dot-notation path to the attribute (e.g., "amm.base_asset_reserve")
+        indent (int, optional): Number of spaces to indent the output. Defaults to 0.
+        
+    Returns:
+        str: Formatted string representation of the attribute and its value
+    """
+    parts = attr_path.split('.')
+    current = obj
+    
+    for part in parts:
+        if hasattr(current, part):
+            current = getattr(current, part)
+        else:
+            return f"{' ' * indent}{attr_path}: Attribute not found"
+    
+    # Special handling for name attribute (regardless of how it's accessed)
+    if attr_path.endswith('name') and isinstance(current, list) and len(current) > 0 and isinstance(current[0], int):
+        return f"{' ' * indent}{attr_path}: {format_market_name(current)}"
+    
+    # Format the value based on its type
+    if hasattr(current, '__class__'):
+        # Special handling for Pubkey objects
+        if current.__class__.__name__ == 'Pubkey':
+            value = format_pubkey(str(current))
+        # For other custom objects, display the class name
+        elif current.__class__.__name__ not in ['int', 'str', 'float', 'bool']:
+            try:
+                # For enum types, display the class name
+                value = current.__class__.__name__
+            except:
+                value = str(current)
+        # For basic types, apply specific formatting based on attribute path
+        elif isinstance(current, int) and 'price' in attr_path.lower():
+            # For price values, format with decimals
+            value = format_number(current)
+        elif isinstance(current, int) and any(x in attr_path.lower() for x in ['reserve', 'balance', 'amount']):
+            # For balance/reserve values, format with decimals
+            value = format_number(current)
+        elif isinstance(current, int) and any(x in attr_path.lower() for x in ['ratio', 'weight', 'factor']):
+            # For ratio/weight values, format with fewer decimals
+            value = format_number(current, 4)
+        else:
+            # Default string conversion for basic types
+            value = str(current)
+    elif isinstance(current, list) and len(current) > 0 and isinstance(current[0], int):
+        # For byte arrays (like name), try to decode as UTF-8
+        try:
+            value = format_market_name(current)
+        except:
+            value = str(current)
+    else:
+        # Default formatting for other types
+        value = str(current)
+    
+    return f"{' ' * indent}{attr_path}: {value}"
+
+def select_attributes(all_attributes):
+    """
+    Interactive interface for selecting which attributes to display.
+    
+    This function provides several selection methods:
+    1. Individual selection: Enter specific numbers (e.g., "1,3,5")
+    2. All attributes: Enter "all"
+    3. Basic attributes: Enter "basic" for commonly used attributes
+    4. Group selection: Enter "group:name" to select all attributes in a group
+    
+    Args:
+        all_attributes (List[str]): Complete list of available attributes
+        
+    Returns:
+        List[str]: Selected attribute paths to display
+    """
+    print("\nAvailable attributes:")
+    
+    # Group attributes for easier selection
+    groups = {}
+    for i, attr in enumerate(all_attributes, 1):
+        # Group by first part of the attribute path
+        group_name = attr.split('.')[0] if '.' in attr else 'base'
+        if group_name not in groups:
+            groups[group_name] = []
+        groups[group_name].append((i, attr))
+    
+    # Display grouped attributes
+    for group_name, attrs in groups.items():
+        print(f"\n{group_name.upper()} Attributes:")
+        for i, attr in attrs:
+            print(f"{i}. {attr}")
+    
+    # Provide options for selection
+    print("\nSelection options:")
+    print("- Enter specific numbers separated by commas (e.g., '1,3,5')")
+    print("- Enter 'all' to select all attributes")
+    print("- Enter 'basic' for a basic set of common attributes")
+    print("- Enter 'group:[name]' to select all attributes in a group (e.g., 'group:amm')")
+    
+    # Get user selection
+    selection = input("\nEnter your selection: ").strip().lower()
+    
+    if selection == 'all':
+        return all_attributes
+    
+    if selection == 'basic':
+        # Return a small set of basic attributes
+        if 'market_index' in all_attributes:  # Checking if this is a spot or perp market
+            basic_attrs = ["pubkey", "name", "market_index", "status"]
+            if "amm.base_asset_reserve" in all_attributes:  # Perp market
+                return basic_attrs + ["contract_type", "amm.base_asset_reserve", 
+                                     "amm.quote_asset_reserve", "amm.oracle_source",
+                                     "margin_ratio_initial", "margin_ratio_maintenance"]
+            else:  # Spot market
+                return basic_attrs + ["decimals", "asset_tier", "oracle_source", 
+                                     "deposit_balance", "borrow_balance", 
+                                     "initial_asset_weight", "maintenance_asset_weight"]
+    
+    if selection.startswith('group:'):
+        # Select all attributes in a group
+        group_name = selection.split(':')[1]
+        selected_attrs = []
+        for group, attrs in groups.items():
+            if group.lower() == group_name:
+                selected_attrs.extend([attr for _, attr in attrs])
+        return selected_attrs
+    
+    # Parse individual numbers
+    try:
+        indices = [int(idx.strip()) for idx in selection.split(',')]
+        return [all_attributes[i-1] for i in indices if 1 <= i <= len(all_attributes)]
+    except:
+        print("Invalid selection. Showing basic attributes.")
+        return select_attributes('basic')
+
+def print_market_details(market, is_perp, selected_attrs=None):
+    """
+    Print details for a market based on selected attributes.
+    
+    This function displays market information in a formatted way, handling both
+    perpetual and spot markets. If no attributes are selected, it prompts the
+    user to choose which attributes to display.
+    
+    Args:
+        market: The market object (PerpMarketAccount or SpotMarketAccount)
+        is_perp (bool): True if this is a perpetual market, False if spot
+        selected_attrs (List[str], optional): Pre-selected attributes to display.
+            If None, user will be prompted to select attributes.
+    """
+    market_type = "Perpetual" if is_perp else "Spot"
+    print(f"\n=== {market_type} Market Details ===")
+    
+    # Get all available attributes
+    all_attrs = get_perp_market_attributes() if is_perp else get_spot_market_attributes()
+    
+    # If no attributes selected, ask user to select
+    if selected_attrs is None:
+        selected_attrs = select_attributes(all_attrs)
+    
+    # Display each selected attribute
+    for attr in selected_attrs:
+        print(display_nested_attribute(market.data, attr))
+
+async def main():
+    """
+    Main entry point for the Drift Protocol Market Explorer.
+    
+    This function:
+    1. Initializes market maps for both perpetual and spot markets
+    2. Fetches all available markets from the Drift Protocol
+    3. Provides an interactive interface for:
+       - Viewing available markets
+       - Selecting markets to inspect
+       - Choosing which attributes to display
+    4. Maintains separate attribute selections for perpetual and spot markets
+    
+    The function runs in an infinite loop until the user chooses to exit by
+    entering 'exit' when prompted for market selection.
+    """
+    # Create MarketMaps for both perpetual and spot markets
+    perp_market_map = MarketMap(
+        MarketMapConfig(
+            drift_client.program,
+            MarketType.Perp(),
+            WebsocketConfig(resub_timeout_ms=10000),
+            connection,
+        )
+    )
+
+    spot_market_map = MarketMap(
+        MarketMapConfig(
+            drift_client.program,
+            MarketType.Spot(),
+            WebsocketConfig(resub_timeout_ms=10000),
+            connection,
+        )
+    )
+
+    print("\nFetching Spot Markets...")
+    await spot_market_map.pre_dump()
+
+    # Pre-dump to fetch all markets
+    print("\nFetching Perpetual Markets...")
+    await perp_market_map.pre_dump()
+    
+    
+    # Create a combined list of markets with their type and sort by market index
+    spot_markets = list(spot_market_map.values())
+    perp_markets = list(perp_market_map.values())
+    
+    # Create separate lists for spot and perp markets
+    spot_market_list = [(m.data.market_index, "S", m, False) for m in spot_markets]
+    perp_market_list = [(m.data.market_index, "P", m, True) for m in perp_markets]
+    
+    # Sort each list by market index
+    spot_market_list.sort(key=lambda x: x[0])
+    perp_market_list.sort(key=lambda x: x[0])
+    
+    # Store combined list for selection logic
+    all_markets = spot_market_list + perp_market_list
+    
+    # Print available markets
+    print("\nAvailable Markets:")
+    print("\nSpot Markets:")
+    for market_index, prefix, market, _ in spot_market_list:
+        print(f"{prefix}{market_index}. Name: {format_market_name(market.data.name)}")
+
+    print("\nPerpetual Markets:")
+    for market_index, prefix, market, _ in perp_market_list:
+        print(f"{prefix}{market_index}. Name: {format_market_name(market.data.name)}")
+
+    # Track selected attributes for each market type
+    perp_selected_attrs = None
+    spot_selected_attrs = None
+
+    # Get user input for market selection
+    while True:
+        try:
+            selection = input("\nEnter market ID (e.g., 'P0' or 'S1') to inspect (or 'exit' to quit): ").strip().upper()
+            if selection == 'EXIT':
+                break
+                
+            if not (selection.startswith('P') or selection.startswith('S')):
+                print("Invalid input. Please use format 'P0' for perp markets or 'S1' for spot markets.")
+                continue
+                
+            try:
+                market_index = int(selection[1:])
+                market_type = selection[0]
+                
+                # Find the market in our sorted list
+                selected_market = None
+                for _, prefix, market, is_perp in all_markets:
+                    if prefix == market_type and market.data.market_index == market_index:
+                        selected_market = market
+                        
+                        # Ask if user wants to reuse previous attribute selection
+                        reuse_attrs = False
+                        current_attrs = None
+                        
+                        if is_perp and perp_selected_attrs:
+                            reuse = input("Do you want to use the same attributes as before? (y/n): ").strip().lower()
+                            reuse_attrs = reuse.startswith('y')
+                            if reuse_attrs:
+                                current_attrs = perp_selected_attrs
+                                
+                        elif not is_perp and spot_selected_attrs:
+                            reuse = input("Do you want to use the same attributes as before? (y/n): ").strip().lower()
+                            reuse_attrs = reuse.startswith('y')
+                            if reuse_attrs:
+                                current_attrs = spot_selected_attrs
+                        
+                        # If not reusing, select new attributes
+                        if not reuse_attrs:
+                            if is_perp:
+                                perp_selected_attrs = select_attributes(get_perp_market_attributes())
+                                current_attrs = perp_selected_attrs
+                            else:
+                                spot_selected_attrs = select_attributes(get_spot_market_attributes())
+                                current_attrs = spot_selected_attrs
+                        
+                        # Print market details with selected attributes
+                        print_market_details(market, is_perp, current_attrs)
+                        break
+                
+                if selected_market is None:
+                    print(f"Market {selection} not found.")
+            except ValueError:
+                print("Invalid market index. Please enter a valid number after P/S.")
+                
+        except Exception as e:
+            print(f"Error: {str(e)}")
+            break
+
+if __name__ == "__main__":
+    """
+    Script entry point.
+    
+    This script provides an interactive interface to explore Drift Protocol markets.
+    When run directly, it:
+    1. Sets up the necessary client connections
+    2. Fetches all available markets
+    3. Provides an interactive prompt for market exploration
+    
+    Environment Variables Required:
+    - RPC_URL: Solana RPC endpoint URL
+    
+    Example Usage:
+    ```bash
+    # Set up environment
+    export RPC_URL="https://your-rpc-endpoint.com"
+    
+    # Run the script
+    python driftpy-marketmap-details.py
+    ```
+    
+    The script will continue running until the user enters 'exit' at the market
+    selection prompt or encounters an error.
+    """
+    # asyncio.run() creates a new event loop, runs the main() coroutine until it completes,
+    # and then closes the event loop.
+    asyncio.run(main())


### PR DESCRIPTION
- Introduced `authority_user-account_lookup.py` for looking up user accounts based on authority addresses, including CSV loading and user account normalization.
- Added `driftpy-enhanced-usermap.py` to provide a detailed view of user positions and balances on the Drift Protocol, supporting both authority and account queries.
- Created `driftpy-marketmap-details.py` for exploring and inspecting markets on the Drift Protocol, allowing users to view and analyze market attributes interactively.

These scripts enhance the functionality and usability of the Drift Protocol tools, providing comprehensive data access and visualization capabilities.