### PR TITLE
websocket logprovider endpoint fix and increase timeout for getProgra…

### DIFF
--- a/src/driftpy/constants/config.py
+++ b/src/driftpy/constants/config.py
@@ -178,7 +178,7 @@ async def find_all_market_and_oracles(
         json=perp_request,
         headers={"content-encoding": "gzip"},
     )
-    resp = await asyncio.wait_for(post, timeout=10)
+    resp = await asyncio.wait_for(post, timeout=30)
     parsed_resp = jsonrpcclient.parse(resp.json())
 
     if isinstance(parsed_resp, jsonrpcclient.Error):
@@ -210,7 +210,7 @@ async def find_all_market_and_oracles(
         json=spot_request,
         headers={"content-encoding": "gzip"},
     )
-    resp = await asyncio.wait_for(post, timeout=10)
+    resp = await asyncio.wait_for(post, timeout=30)
     parsed_resp = jsonrpcclient.parse(resp.json())
 
     if isinstance(parsed_resp, jsonrpcclient.Error):

--- a/src/driftpy/events/websocket_log_provider.py
+++ b/src/driftpy/events/websocket_log_provider.py
@@ -12,6 +12,7 @@ from typing import cast
 import websockets.exceptions
 
 from driftpy.events.types import LogProviderCallback, LogProvider
+from driftpy.types import get_ws_url
 
 
 class WebsocketLogProvider(LogProvider):
@@ -29,7 +30,11 @@ class WebsocketLogProvider(LogProvider):
 
     async def subscribe_ws(self, callback: LogProviderCallback):
         endpoint = self.connection._provider.endpoint_uri
-        ws_endpoint = endpoint.replace("https", "wss").replace("http", "ws")
+        if endpoint.startswith("http"):
+            ws_endpoint = get_ws_url(endpoint)
+        else:
+            ws_endpoint = endpoint
+
         async for ws in connect(ws_endpoint):
             ws: SolanaWsClientProtocol
             try:


### PR DESCRIPTION
1. Fix: ws_endpoint in `src/driftpy/events/websocket_log_provider.py`: we would need to increase the port number by 1 if the given URL is for HTTP.
2. The getProgramAccounts RPC method can be computationally intensive; therefore timeout of just 10 seconds is not sufficient. The timeout for getProgramAccounts in the SDK code in other code sections is either 30 or 120 seconds.