### PR TITLE
refactor: add frequency and batch_size to WebsocketLogProviderConfig

### DIFF
--- a/src/driftpy/events/types.py
+++ b/src/driftpy/events/types.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from dataclasses import dataclass, field
-from typing import Callable, Literal, Union
+from typing import Callable, Literal, Union, Optional
 
 from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Commitment
@@ -86,13 +86,14 @@ EventSubscriptionOrderDirection = Union[Asc, Desc]
 
 @dataclass
 class WebsocketLogProviderConfig:
-    pass
+    frequency: float = 1
+    batch_size: Optional[int] = None
 
 
 @dataclass
 class PollingLogProviderConfig:
     frequency: float = 1
-    batch_size: int = None
+    batch_size: Optional[int] = None
 
 
 LogProviderConfig = Union[


### PR DESCRIPTION
This change aligns WebsocketLogProviderConfig with PollingLogProviderConfig by adding configurable frequency and batch_size parameters. The batch_size field is now typed as Optional[int] with a default of None.