### PR TITLE
add json api reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 DriftPy is the Python client for the [Drift](https://www.drift.trade/) protocol.
 It allows you to trade and fetch data from Drift using Python.
 
-**[Read the full SDK documentation here!](https://drift-labs.github.io/v2-teacher/)**
+**[Read the full SDK documentation here!](https://docs.drift.trade/)**
 
 ## Installation
 
@@ -17,19 +17,17 @@ pip install driftpy
 
 Note: requires Python >= 3.10.
 
-
 ## SDK Examples
 
 - `examples/` folder includes more examples of how to use the SDK including how to provide liquidity/become an lp, stake in the insurance fund, etc.
 
-
 ## Note on using QuickNode
 
-If you are using QuickNode free plan, you *must* use `AccountSubscriptionConfig("demo")`, and you can only subscribe to 1 perp market and 1 spot market at a time.
+If you are using QuickNode free plan, you _must_ use `AccountSubscriptionConfig("demo")`, and you can only subscribe to 1 perp market and 1 spot market at a time.
 
 Non-QuickNode free RPCs (including the public mainnet-beta url) can use `cached` as well.
 
-Example setup for `AccountSubscriptionConfig("demo")`: 
+Example setup for `AccountSubscriptionConfig("demo")`:
 
 ```python
     # This example will listen to perp markets 0 & 1 and spot market 0
@@ -42,8 +40,8 @@ Example setup for `AccountSubscriptionConfig("demo")`:
 
     drift_client = DriftClient(
         connection,
-        wallet, 
-        "mainnet",             
+        wallet,
+        "mainnet",
         perp_market_indexes = perp_markets,
         spot_market_indexes = spot_market_indexes,
         oracle_infos = oracle_infos,
@@ -51,7 +49,8 @@ Example setup for `AccountSubscriptionConfig("demo")`:
     )
     await drift_client.subscribe()
 ```
-If you intend to use `AccountSubscriptionConfig("demo)`, you *must* call `get_markets_and_oracles` to get the information you need.
+
+If you intend to use `AccountSubscriptionConfig("demo)`, you _must_ call `get_markets_and_oracles` to get the information you need.
 
 `get_markets_and_oracles` will return all the necessary `OracleInfo`s and `market_indexes` in order to use the SDK.
 
@@ -61,8 +60,8 @@ If you intend to use `AccountSubscriptionConfig("demo)`, you *must* call `get_ma
 
 `bash setup.sh`
 
-
 Ensure correct python version (using pyenv is recommended):
+
 ```bash
 pyenv install 3.10.11
 pyenv global 3.10.11
@@ -70,11 +69,13 @@ poetry env use $(pyenv which python)
 ```
 
 Install dependencies:
+
 ```bash
 poetry install
 ```
 
 To run tests, first ensure you have set up the RPC url, then run `pytest`:
+
 ```bash
 export MAINNET_RPC_ENDPOINT="<YOUR_RPC_URL>"
 export DEVNET_RPC_ENDPOINT="https://api.devnet.solana.com" # or your own RPC
@@ -82,3 +83,15 @@ export DEVNET_RPC_ENDPOINT="https://api.devnet.solana.com" # or your own RPC
 poetry run pytest -v -s -x tests/ci/*.py
 poetry run pytest -v -s tests/math/*.py
 ```
+
+## Export API Reference (JSON)
+
+Generate a public API inventory for classes, methods, functions, and constants:
+
+```bash
+/usr/bin/python3 scripts/export_api_docs.py
+```
+
+Outputs:
+
+- `docs/generated/api_reference.json`

--- a/docs/generated/api_reference.json
+++ b/docs/generated/api_reference.json
@@ -1,0 +1,28850 @@
+[
+  {
+    "module": "driftpy.accounts.bulk_account_loader",
+    "path": "accounts/bulk_account_loader.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "GET_MULTIPLE_ACCOUNTS_CHUNK_SIZE"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "AccountToLoad",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "BufferAndSlot",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "BulkAccountLoader",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "connection",
+                "kind": "positional_or_keyword",
+                "type": "AsyncClient",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "commitment",
+                "kind": "positional_or_keyword",
+                "type": "Commitment",
+                "required": false,
+                "default": "'confirmed'"
+              },
+              {
+                "name": "frequency",
+                "kind": "positional_or_keyword",
+                "type": "float",
+                "required": false,
+                "default": "1"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, connection: AsyncClient, commitment: Commitment = 'confirmed', frequency: float = 1)"
+          },
+          {
+            "name": "add_account",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "pubkey",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "callback",
+                "kind": "positional_or_keyword",
+                "type": "Callable[[bytes, int], None]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self, pubkey: Pubkey, callback: Callable[[bytes, int], None]) -> int"
+          },
+          {
+            "name": "chunks",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "array",
+                "kind": "positional_or_keyword",
+                "type": "List",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "size",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "List[List]"
+            },
+            "signature": "(self, array: List, size: int) -> List[List]"
+          },
+          {
+            "name": "get_callback_id",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self) -> int"
+          },
+          {
+            "name": "handle_callbacks",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "account_to_load",
+                "kind": "positional_or_keyword",
+                "type": "AccountToLoad",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "buffer",
+                "kind": "positional_or_keyword",
+                "type": "Optional[bytes]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, account_to_load: AccountToLoad, buffer: Optional[bytes], slot: int)"
+          },
+          {
+            "name": "load",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "load_chunk",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "chunk",
+                "kind": "positional_or_keyword",
+                "type": "List[List[AccountToLoad]]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, chunk: List[List[AccountToLoad]])"
+          },
+          {
+            "name": "remove_account",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "pubkey",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "callback_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, pubkey: Pubkey, callback_id: int)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.accounts.cache.drift_client",
+    "path": "accounts/cache/drift_client.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "T"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "CachedDriftClientAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "program",
+                "kind": "positional_or_keyword",
+                "type": "Program",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_market_indexes",
+                "kind": "positional_or_keyword",
+                "type": "list[int]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_indexes",
+                "kind": "positional_or_keyword",
+                "type": "list[int]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_infos",
+                "kind": "positional_or_keyword",
+                "type": "list[OracleInfo]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "should_find_all_markets_and_oracles",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "True"
+              },
+              {
+                "name": "commitment",
+                "kind": "positional_or_keyword",
+                "type": "Commitment",
+                "required": false,
+                "default": "Confirmed"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, program: Program, perp_market_indexes: list[int], spot_market_indexes: list[int], oracle_infos: list[OracleInfo], should_find_all_markets_and_oracles: bool = True, commitment: Commitment = Confirmed)"
+          },
+          {
+            "name": "fetch",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get_market_accounts_and_slots",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "list[DataAndSlot[PerpMarketAccount]]"
+            },
+            "signature": "(self) -> list[DataAndSlot[PerpMarketAccount]]"
+          },
+          {
+            "name": "get_oracle_price_data_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_id",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[OraclePriceData]]"
+            },
+            "signature": "(self, oracle_id: str) -> Optional[DataAndSlot[OraclePriceData]]"
+          },
+          {
+            "name": "get_oracle_price_data_and_slot_for_perp_market",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[OraclePriceData]"
+            },
+            "signature": "(self, market_index: int) -> Optional[OraclePriceData]"
+          },
+          {
+            "name": "get_oracle_price_data_and_slot_for_spot_market",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[OraclePriceData]"
+            },
+            "signature": "(self, market_index: int) -> Optional[OraclePriceData]"
+          },
+          {
+            "name": "get_perp_market_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[PerpMarketAccount]]"
+            },
+            "signature": "(self, market_index: int) -> Optional[DataAndSlot[PerpMarketAccount]]"
+          },
+          {
+            "name": "get_spot_market_accounts_and_slots",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "list[DataAndSlot[SpotMarketAccount]]"
+            },
+            "signature": "(self) -> list[DataAndSlot[SpotMarketAccount]]"
+          },
+          {
+            "name": "get_spot_market_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[SpotMarketAccount]]"
+            },
+            "signature": "(self, market_index: int) -> Optional[DataAndSlot[SpotMarketAccount]]"
+          },
+          {
+            "name": "get_state_account_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[StateAccount]]"
+            },
+            "signature": "(self) -> Optional[DataAndSlot[StateAccount]]"
+          },
+          {
+            "name": "resurrect",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_markets",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_markets",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_oracles",
+                "kind": "positional_or_keyword",
+                "type": "dict[int, OraclePriceData]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_oracles",
+                "kind": "positional_or_keyword",
+                "type": "dict[int, OraclePriceData]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_markets, perp_markets, spot_oracles: dict[int, OraclePriceData], perp_oracles: dict[int, OraclePriceData])"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "update_cache",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      },
+      {
+        "name": "DriftClientCache",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.accounts.cache.user",
+    "path": "accounts/cache/user.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "CachedUserAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_pubkey",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "program",
+                "kind": "positional_or_keyword",
+                "type": "Program",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "commitment",
+                "kind": "positional_or_keyword",
+                "type": "Commitment",
+                "required": false,
+                "default": "'confirmed'"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_pubkey: Pubkey, program: Program, commitment: Commitment = 'confirmed')"
+          },
+          {
+            "name": "fetch",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get_user_account_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[UserAccount]]"
+            },
+            "signature": "(self) -> Optional[DataAndSlot[UserAccount]]"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "update_cache",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "update_data",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "data",
+                "kind": "positional_or_keyword",
+                "type": "Optional[DataAndSlot[UserAccount]]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, data: Optional[DataAndSlot[UserAccount]])"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.accounts.demo.drift_client",
+    "path": "accounts/demo/drift_client.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "DemoDriftClientAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "program",
+                "kind": "positional_or_keyword",
+                "type": "Program",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_market_indexes",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_indexes",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_infos",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "commitment",
+                "kind": "positional_or_keyword",
+                "type": "Commitment",
+                "required": false,
+                "default": "'confirmed'"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, program: Program, perp_market_indexes, spot_market_indexes, oracle_infos, commitment: Commitment = 'confirmed')"
+          },
+          {
+            "name": "fetch",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get_market_accounts_and_slots",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "list[DataAndSlot[PerpMarketAccount]]"
+            },
+            "signature": "(self) -> list[DataAndSlot[PerpMarketAccount]]"
+          },
+          {
+            "name": "get_oracle_price_data_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_id",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[OraclePriceData]]"
+            },
+            "signature": "(self, oracle_id: str) -> Optional[DataAndSlot[OraclePriceData]]"
+          },
+          {
+            "name": "get_perp_market_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[PerpMarketAccount]]"
+            },
+            "signature": "(self, market_index: int) -> Optional[DataAndSlot[PerpMarketAccount]]"
+          },
+          {
+            "name": "get_spot_market_accounts_and_slots",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "list[DataAndSlot[SpotMarketAccount]]"
+            },
+            "signature": "(self) -> list[DataAndSlot[SpotMarketAccount]]"
+          },
+          {
+            "name": "get_spot_market_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[SpotMarketAccount]]"
+            },
+            "signature": "(self, market_index: int) -> Optional[DataAndSlot[SpotMarketAccount]]"
+          },
+          {
+            "name": "get_state_account_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[StateAccount]]"
+            },
+            "signature": "(self) -> Optional[DataAndSlot[StateAccount]]"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "update_cache",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.accounts.demo.user",
+    "path": "accounts/demo/user.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "DemoUserAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_pubkey",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "program",
+                "kind": "positional_or_keyword",
+                "type": "Program",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "commitment",
+                "kind": "positional_or_keyword",
+                "type": "Commitment",
+                "required": false,
+                "default": "'confirmed'"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_pubkey: Pubkey, program: Program, commitment: Commitment = 'confirmed')"
+          },
+          {
+            "name": "fetch",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get_user_account_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[UserAccount]]"
+            },
+            "signature": "(self) -> Optional[DataAndSlot[UserAccount]]"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "update_cache",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "update_data",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "data",
+                "kind": "positional_or_keyword",
+                "type": "Optional[DataAndSlot[UserAccount]]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, data: Optional[DataAndSlot[UserAccount]])"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.accounts.get_accounts",
+    "path": "accounts/get_accounts.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "get_account_data_and_slot",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "address",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "commitment",
+            "kind": "positional_or_keyword",
+            "type": "Commitment",
+            "required": false,
+            "default": "Commitment('processed')"
+          },
+          {
+            "name": "decode",
+            "kind": "positional_or_keyword",
+            "type": "Optional[Callable[[bytes], T]]",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "returns": {
+          "type": "Optional[DataAndSlot[T]]"
+        },
+        "signature": "(address: Pubkey, program: Program, commitment: Commitment = Commitment('processed'), decode: Optional[Callable[[bytes], T]] = None) -> Optional[DataAndSlot[T]]"
+      },
+      {
+        "name": "get_all_perp_market_accounts",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "list[ProgramAccount]"
+        },
+        "signature": "(program: Program) -> list[ProgramAccount]"
+      },
+      {
+        "name": "get_all_spot_market_accounts",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "list[ProgramAccount]"
+        },
+        "signature": "(program: Program) -> list[ProgramAccount]"
+      },
+      {
+        "name": "get_if_stake_account",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "authority",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "spot_market_index",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "InsuranceFundStakeAccount"
+        },
+        "signature": "(program: Program, authority: Pubkey, spot_market_index: int) -> InsuranceFundStakeAccount"
+      },
+      {
+        "name": "get_perp_market_account",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "market_index",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Optional[PerpMarketAccount]"
+        },
+        "signature": "(program: Program, market_index: int) -> Optional[PerpMarketAccount]"
+      },
+      {
+        "name": "get_perp_market_account_and_slot",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "market_index",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Optional[DataAndSlot[PerpMarketAccount]]"
+        },
+        "signature": "(program: Program, market_index: int) -> Optional[DataAndSlot[PerpMarketAccount]]"
+      },
+      {
+        "name": "get_protected_maker_mode_stats",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "dict[str, int | bool]"
+        },
+        "signature": "(program: Program) -> dict[str, int | bool]"
+      },
+      {
+        "name": "get_spot_market_account",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "spot_market_index",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Optional[SpotMarketAccount]"
+        },
+        "signature": "(program: Program, spot_market_index: int) -> Optional[SpotMarketAccount]"
+      },
+      {
+        "name": "get_spot_market_account_and_slot",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "spot_market_index",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Optional[DataAndSlot[SpotMarketAccount]]"
+        },
+        "signature": "(program: Program, spot_market_index: int) -> Optional[DataAndSlot[SpotMarketAccount]]"
+      },
+      {
+        "name": "get_state_account",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "StateAccount"
+        },
+        "signature": "(program: Program) -> StateAccount"
+      },
+      {
+        "name": "get_state_account_and_slot",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "DataAndSlot[StateAccount]"
+        },
+        "signature": "(program: Program) -> DataAndSlot[StateAccount]"
+      },
+      {
+        "name": "get_user_account",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "user_public_key",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Optional[UserAccount]"
+        },
+        "signature": "(program: Program, user_public_key: Pubkey) -> Optional[UserAccount]"
+      },
+      {
+        "name": "get_user_account_and_slot",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "user_public_key",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Optional[DataAndSlot[UserAccount]]"
+        },
+        "signature": "(program: Program, user_public_key: Pubkey) -> Optional[DataAndSlot[UserAccount]]"
+      },
+      {
+        "name": "get_user_stats_account",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "authority",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "UserStatsAccount"
+        },
+        "signature": "(program: Program, authority: Pubkey) -> UserStatsAccount"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.accounts.grpc.account_subscriber",
+    "path": "accounts/grpc/account_subscriber.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "T"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "GrpcAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "grpc_config",
+                "kind": "positional_or_keyword",
+                "type": "GrpcConfig",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "account_name",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "program",
+                "kind": "positional_or_keyword",
+                "type": "Program",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "account_public_key",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "commitment",
+                "kind": "positional_or_keyword",
+                "type": "Commitment",
+                "required": false,
+                "default": "Commitment('confirmed')"
+              },
+              {
+                "name": "decode",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Callable[[bytes], T]]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "initial_data",
+                "kind": "positional_or_keyword",
+                "type": "Optional[DataAndSlot[T]]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, grpc_config: GrpcConfig, account_name: str, program: Program, account_public_key: Pubkey, commitment: Commitment = Commitment('confirmed'), decode: Optional[Callable[[bytes], T]] = None, initial_data: Optional[DataAndSlot[T]] = None)"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[asyncio.Task[None]]"
+            },
+            "signature": "(self) -> Optional[asyncio.Task[None]]"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self) -> None"
+          },
+          {
+            "name": "update_data",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "new_data",
+                "kind": "positional_or_keyword",
+                "type": "Optional[DataAndSlot[T]]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, new_data: Optional[DataAndSlot[T]])"
+          }
+        ]
+      },
+      {
+        "name": "TritonAuthMetadataPlugin",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "x_token",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, x_token: str)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.accounts.grpc.drift_client",
+    "path": "accounts/grpc/drift_client.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "GrpcDriftClientAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "program",
+                "kind": "positional_or_keyword",
+                "type": "Program",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "grpc_config",
+                "kind": "positional_or_keyword",
+                "type": "GrpcConfig",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_market_indexes",
+                "kind": "positional_or_keyword",
+                "type": "Sequence[int]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_indexes",
+                "kind": "positional_or_keyword",
+                "type": "Sequence[int]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "full_oracle_wrappers",
+                "kind": "positional_or_keyword",
+                "type": "Sequence[FullOracleWrapper]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "should_find_all_markets_and_oracles",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "commitment",
+                "kind": "positional_or_keyword",
+                "type": "Commitment",
+                "required": false,
+                "default": "Commitment('confirmed')"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, program: Program, grpc_config: GrpcConfig, perp_market_indexes: Sequence[int], spot_market_indexes: Sequence[int], full_oracle_wrappers: Sequence[FullOracleWrapper], should_find_all_markets_and_oracles: bool, commitment: Commitment = Commitment('confirmed'))"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "subscribe_to_oracle",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "full_oracle_wrapper",
+                "kind": "positional_or_keyword",
+                "type": "FullOracleWrapper",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, full_oracle_wrapper: FullOracleWrapper)"
+          },
+          {
+            "name": "subscribe_to_perp_market",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int)"
+          },
+          {
+            "name": "subscribe_to_spot_market",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.accounts.grpc.geyser_codegen.subscribe_geyser",
+    "path": "accounts/grpc/geyser_codegen/subscribe_geyser.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "create_subscribe_request",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [],
+        "returns": {
+          "type": "Iterator[geyser_pb2.SubscribeRequest]"
+        },
+        "signature": "() -> Iterator[geyser_pb2.SubscribeRequest]"
+      },
+      {
+        "name": "handle_subscribe_updates",
+        "is_async": false,
+        "docstring": "Handles the streaming updates from the subscription.\nEach update can contain different types of data based on our filters.",
+        "arguments": [
+          {
+            "name": "stub",
+            "kind": "positional_or_keyword",
+            "type": "geyser_pb2_grpc.GeyserStub",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(stub: geyser_pb2_grpc.GeyserStub)"
+      },
+      {
+        "name": "run_subscription_client",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [],
+        "returns": {
+          "type": null
+        },
+        "signature": "()"
+      }
+    ],
+    "classes": [
+      {
+        "name": "TritonAuthMetadataPlugin",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "x_token",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, x_token: str)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.accounts.grpc.program_account_subscriber",
+    "path": "accounts/grpc/program_account_subscriber.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "T"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "GrpcProgramAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "subscription_name",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "program",
+                "kind": "positional_or_keyword",
+                "type": "Program",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "grpc_config",
+                "kind": "positional_or_keyword",
+                "type": "GrpcConfig",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "on_update",
+                "kind": "positional_or_keyword",
+                "type": "Optional[UpdateCallback | MarketUpdateCallback]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "options",
+                "kind": "positional_or_keyword",
+                "type": "GrpcProgramAccountOptions",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "decode",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Callable[[bytes], T]]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, subscription_name: str, program: Program, grpc_config: GrpcConfig, on_update: Optional[UpdateCallback | MarketUpdateCallback], options: GrpcProgramAccountOptions, decode: Optional[Callable[[bytes], T]] = None)"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.accounts.grpc.user",
+    "path": "accounts/grpc/user.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "GrpcUserAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "get_user_account_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[UserAccount]]"
+            },
+            "signature": "(self) -> Optional[DataAndSlot[UserAccount]]"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.accounts.grpc.user_stats",
+    "path": "accounts/grpc/user_stats.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "GrpcUserStatsAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "get_user_stats_account_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[UserStatsAccount]]"
+            },
+            "signature": "(self) -> Optional[DataAndSlot[UserStatsAccount]]"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.accounts.oracle",
+    "path": "accounts/oracle.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "DRIFT_CODER"
+      },
+      {
+        "name": "DRIFT_IDL"
+      },
+      {
+        "name": "IDL"
+      },
+      {
+        "name": "SWB_CODER"
+      },
+      {
+        "name": "SWB_ON_DEMAND_CODER"
+      },
+      {
+        "name": "SWB_ON_DEMAND_IDL"
+      }
+    ],
+    "functions": [
+      {
+        "name": "convert_pyth_price",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "price",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "scale",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": false,
+            "default": "1"
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(price, scale = 1)"
+      },
+      {
+        "name": "convert_switchboard_decimal",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "mantissa",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "scale",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": false,
+            "default": "1"
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(mantissa: int, scale: int = 1)"
+      },
+      {
+        "name": "decode_oracle",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "oracle_ai",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_source",
+            "kind": "positional_or_keyword",
+            "type": "OracleSource",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(oracle_ai: bytes, oracle_source: OracleSource)"
+      },
+      {
+        "name": "decode_prelaunch_price_info",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "data",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(data: bytes)"
+      },
+      {
+        "name": "decode_pyth_lazer_price_info",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "data",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "multiple",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": false,
+            "default": "1"
+          },
+          {
+            "name": "stable_coin",
+            "kind": "positional_or_keyword",
+            "type": "bool",
+            "required": false,
+            "default": "False"
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(data: bytes, multiple: int = 1, stable_coin: bool = False)"
+      },
+      {
+        "name": "decode_pyth_price_info",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "buffer",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_source",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": false,
+            "default": "OracleSource.Pyth()"
+          }
+        ],
+        "returns": {
+          "type": "OraclePriceData"
+        },
+        "signature": "(buffer: bytes, oracle_source = OracleSource.Pyth()) -> OraclePriceData"
+      },
+      {
+        "name": "decode_pyth_pull_price_info",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "data",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_source",
+            "kind": "positional_or_keyword",
+            "type": "OracleSource",
+            "required": false,
+            "default": "OracleSource.PythPull()"
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(data: bytes, oracle_source: OracleSource = OracleSource.PythPull())"
+      },
+      {
+        "name": "decode_swb_on_demand_price_info",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "data",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(data: bytes)"
+      },
+      {
+        "name": "decode_swb_price_info",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "data",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(data: bytes)"
+      },
+      {
+        "name": "get_oracle_decode_fn",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "oracle_source",
+            "kind": "positional_or_keyword",
+            "type": "OracleSource",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(oracle_source: OracleSource)"
+      },
+      {
+        "name": "get_oracle_price_data_and_slot",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "connection",
+            "kind": "positional_or_keyword",
+            "type": "AsyncClient",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "address",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_source",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": false,
+            "default": "OracleSource.Pyth()"
+          }
+        ],
+        "returns": {
+          "type": "DataAndSlot[OraclePriceData]"
+        },
+        "signature": "(connection: AsyncClient, address: Pubkey, oracle_source = OracleSource.Pyth()) -> DataAndSlot[OraclePriceData]"
+      },
+      {
+        "name": "is_pyth_legacy_oracle",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "oracle_source",
+            "kind": "positional_or_keyword",
+            "type": "OracleSource",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(oracle_source: OracleSource)"
+      },
+      {
+        "name": "is_pyth_pull_oracle",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "oracle_source",
+            "kind": "positional_or_keyword",
+            "type": "OracleSource",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(oracle_source: OracleSource)"
+      },
+      {
+        "name": "oracle_ai_to_oracle_price_data",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "oracle_ai",
+            "kind": "positional_or_keyword",
+            "type": "Account",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_source",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": false,
+            "default": "OracleSource.Pyth()"
+          }
+        ],
+        "returns": {
+          "type": "DataAndSlot[OraclePriceData]"
+        },
+        "signature": "(oracle_ai: Account, oracle_source = OracleSource.Pyth()) -> DataAndSlot[OraclePriceData]"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.accounts.polling.drift_client",
+    "path": "accounts/polling/drift_client.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "PollingDriftClientAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "program",
+                "kind": "positional_or_keyword",
+                "type": "Program",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "bulk_account_loader",
+                "kind": "positional_or_keyword",
+                "type": "BulkAccountLoader",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_market_indexes",
+                "kind": "positional_or_keyword",
+                "type": "Sequence[int]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_indexes",
+                "kind": "positional_or_keyword",
+                "type": "Sequence[int]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_infos",
+                "kind": "positional_or_keyword",
+                "type": "Sequence[OracleInfo]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "should_find_all_markets_and_oracles",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, program: Program, bulk_account_loader: BulkAccountLoader, perp_market_indexes: Sequence[int], spot_market_indexes: Sequence[int], oracle_infos: Sequence[OracleInfo], should_find_all_markets_and_oracles: bool)"
+          },
+          {
+            "name": "accounts_ready",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self) -> bool"
+          },
+          {
+            "name": "add_oracle",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_source",
+                "kind": "positional_or_keyword",
+                "type": "OracleSource",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, oracle: Pubkey, oracle_source: OracleSource)"
+          },
+          {
+            "name": "fetch",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get_market_accounts_and_slots",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "list[DataAndSlot[PerpMarketAccount]]"
+            },
+            "signature": "(self) -> list[DataAndSlot[PerpMarketAccount]]"
+          },
+          {
+            "name": "get_oracle_price_data_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_id",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[OraclePriceData]]"
+            },
+            "signature": "(self, oracle_id: str) -> Optional[DataAndSlot[OraclePriceData]]"
+          },
+          {
+            "name": "get_oracle_price_data_and_slot_for_perp_market",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Union[DataAndSlot[OraclePriceData], None]"
+            },
+            "signature": "(self, market_index: int) -> Union[DataAndSlot[OraclePriceData], None]"
+          },
+          {
+            "name": "get_oracle_price_data_and_slot_for_spot_market",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Union[DataAndSlot[OraclePriceData], None]"
+            },
+            "signature": "(self, market_index: int) -> Union[DataAndSlot[OraclePriceData], None]"
+          },
+          {
+            "name": "get_perp_market_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[PerpMarketAccount]]"
+            },
+            "signature": "(self, market_index: int) -> Optional[DataAndSlot[PerpMarketAccount]]"
+          },
+          {
+            "name": "get_spot_market_accounts_and_slots",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "list[DataAndSlot[SpotMarketAccount]]"
+            },
+            "signature": "(self) -> list[DataAndSlot[SpotMarketAccount]]"
+          },
+          {
+            "name": "get_spot_market_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[SpotMarketAccount]]"
+            },
+            "signature": "(self, market_index: int) -> Optional[DataAndSlot[SpotMarketAccount]]"
+          },
+          {
+            "name": "get_state_account_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[StateAccount]]"
+            },
+            "signature": "(self) -> Optional[DataAndSlot[StateAccount]]"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "update_accounts_to_poll",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.accounts.polling.user",
+    "path": "accounts/polling/user.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "PollingUserAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account_pubkey",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "program",
+                "kind": "positional_or_keyword",
+                "type": "Program",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "bulk_account_loader",
+                "kind": "positional_or_keyword",
+                "type": "BulkAccountLoader",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_account_pubkey: Pubkey, program: Program, bulk_account_loader: BulkAccountLoader)"
+          },
+          {
+            "name": "add_to_account_loader",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "fetch",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get_user_account_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[UserAccount]]"
+            },
+            "signature": "(self) -> Optional[DataAndSlot[UserAccount]]"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "update_data",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "new_data",
+                "kind": "positional_or_keyword",
+                "type": "Optional[DataAndSlot[UserAccount]]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, new_data: Optional[DataAndSlot[UserAccount]])"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.accounts.types",
+    "path": "accounts/types.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "T"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "BufferAndSlot",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "DataAndSlot",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "DriftClientAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "fetch",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get_market_accounts_and_slots",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "list[DataAndSlot[PerpMarketAccount]]"
+            },
+            "signature": "(self) -> list[DataAndSlot[PerpMarketAccount]]"
+          },
+          {
+            "name": "get_oracle_price_data_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[OraclePriceData]]"
+            },
+            "signature": "(self, oracle: Pubkey) -> Optional[DataAndSlot[OraclePriceData]]"
+          },
+          {
+            "name": "get_perp_market_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[PerpMarketAccount]]"
+            },
+            "signature": "(self, market_index: int) -> Optional[DataAndSlot[PerpMarketAccount]]"
+          },
+          {
+            "name": "get_spot_market_accounts_and_slots",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "list[DataAndSlot[SpotMarketAccount]]"
+            },
+            "signature": "(self) -> list[DataAndSlot[SpotMarketAccount]]"
+          },
+          {
+            "name": "get_spot_market_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[SpotMarketAccount]]"
+            },
+            "signature": "(self, market_index: int) -> Optional[DataAndSlot[SpotMarketAccount]]"
+          },
+          {
+            "name": "get_state_account_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[StateAccount]]"
+            },
+            "signature": "(self) -> Optional[DataAndSlot[StateAccount]]"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      },
+      {
+        "name": "FullOracleWrapper",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "GrpcProgramAccountOptions",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "UserAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "fetch",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get_user_account_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[UserAccount]]"
+            },
+            "signature": "(self) -> Optional[DataAndSlot[UserAccount]]"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "update_data",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "data",
+                "kind": "positional_or_keyword",
+                "type": "Optional[DataAndSlot[UserAccount]]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, data: Optional[DataAndSlot[UserAccount]])"
+          }
+        ]
+      },
+      {
+        "name": "UserStatsAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "fetch",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get_user_stats_account_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[UserStatsAccount]]"
+            },
+            "signature": "(self) -> Optional[DataAndSlot[UserStatsAccount]]"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      },
+      {
+        "name": "WebsocketProgramAccountOptions",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.accounts.ws.account_subscriber",
+    "path": "accounts/ws/account_subscriber.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "T"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "WebsocketAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "pubkey",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "program",
+                "kind": "positional_or_keyword",
+                "type": "Program",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "commitment",
+                "kind": "positional_or_keyword",
+                "type": "Commitment",
+                "required": false,
+                "default": "Commitment('confirmed')"
+              },
+              {
+                "name": "decode",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Callable[[bytes], T]]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "initial_data",
+                "kind": "positional_or_keyword",
+                "type": "Optional[DataAndSlot]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, pubkey: Pubkey, program: Program, commitment: Commitment = Commitment('confirmed'), decode: Optional[Callable[[bytes], T]] = None, initial_data: Optional[DataAndSlot] = None)"
+          },
+          {
+            "name": "fetch",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "is_subscribed",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "subscribe_ws",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "update_data",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "new_data",
+                "kind": "positional_or_keyword",
+                "type": "Optional[DataAndSlot[T]]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, new_data: Optional[DataAndSlot[T]])"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.accounts.ws.drift_client",
+    "path": "accounts/ws/drift_client.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "WebsocketDriftClientAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "program",
+                "kind": "positional_or_keyword",
+                "type": "Program",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_market_indexes",
+                "kind": "positional_or_keyword",
+                "type": "Sequence[int]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_indexes",
+                "kind": "positional_or_keyword",
+                "type": "Sequence[int]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "full_oracle_wrappers",
+                "kind": "positional_or_keyword",
+                "type": "Sequence[FullOracleWrapper]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "should_find_all_markets_and_oracles",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "commitment",
+                "kind": "positional_or_keyword",
+                "type": "Commitment",
+                "required": false,
+                "default": "Commitment('confirmed')"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, program: Program, perp_market_indexes: Sequence[int], spot_market_indexes: Sequence[int], full_oracle_wrappers: Sequence[FullOracleWrapper], should_find_all_markets_and_oracles: bool, commitment: Commitment = Commitment('confirmed'))"
+          },
+          {
+            "name": "add_oracle",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_info",
+                "kind": "positional_or_keyword",
+                "type": "OracleInfo",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, oracle_info: OracleInfo)"
+          },
+          {
+            "name": "fetch",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get_market_accounts_and_slots",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "list[DataAndSlot[PerpMarketAccount]]"
+            },
+            "signature": "(self) -> list[DataAndSlot[PerpMarketAccount]]"
+          },
+          {
+            "name": "get_oracle_price_data_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_id",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[OraclePriceData]]"
+            },
+            "signature": "(self, oracle_id: str) -> Optional[DataAndSlot[OraclePriceData]]"
+          },
+          {
+            "name": "get_oracle_price_data_and_slot_for_perp_market",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Union[DataAndSlot[OraclePriceData], None]"
+            },
+            "signature": "(self, market_index: int) -> Union[DataAndSlot[OraclePriceData], None]"
+          },
+          {
+            "name": "get_oracle_price_data_and_slot_for_spot_market",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Union[DataAndSlot[OraclePriceData], None]"
+            },
+            "signature": "(self, market_index: int) -> Union[DataAndSlot[OraclePriceData], None]"
+          },
+          {
+            "name": "get_perp_market_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[PerpMarketAccount]]"
+            },
+            "signature": "(self, market_index: int) -> Optional[DataAndSlot[PerpMarketAccount]]"
+          },
+          {
+            "name": "get_spot_market_accounts_and_slots",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "list[DataAndSlot[SpotMarketAccount]]"
+            },
+            "signature": "(self) -> list[DataAndSlot[SpotMarketAccount]]"
+          },
+          {
+            "name": "get_spot_market_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[SpotMarketAccount]]"
+            },
+            "signature": "(self, market_index: int) -> Optional[DataAndSlot[SpotMarketAccount]]"
+          },
+          {
+            "name": "get_state_account_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[StateAccount]]"
+            },
+            "signature": "(self) -> Optional[DataAndSlot[StateAccount]]"
+          },
+          {
+            "name": "is_subscribed",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "subscribe_to_oracle",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "full_oracle_wrapper",
+                "kind": "positional_or_keyword",
+                "type": "FullOracleWrapper",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, full_oracle_wrapper: FullOracleWrapper)"
+          },
+          {
+            "name": "subscribe_to_oracle_info",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_info",
+                "kind": "positional_or_keyword",
+                "type": "OracleInfo | FullOracleWrapper",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, oracle_info: OracleInfo | FullOracleWrapper)"
+          },
+          {
+            "name": "subscribe_to_perp_market",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "initial_data",
+                "kind": "positional_or_keyword",
+                "type": "Optional[DataAndSlot[PerpMarketAccount]]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int, initial_data: Optional[DataAndSlot[PerpMarketAccount]] = None)"
+          },
+          {
+            "name": "subscribe_to_spot_market",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "initial_data",
+                "kind": "positional_or_keyword",
+                "type": "Optional[DataAndSlot[SpotMarketAccount]]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int, initial_data: Optional[DataAndSlot[SpotMarketAccount]] = None)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.accounts.ws.program_account_subscriber",
+    "path": "accounts/ws/program_account_subscriber.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "T"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "WebSocketProgramAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "subscription_name",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "program",
+                "kind": "positional_or_keyword",
+                "type": "Program",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "options",
+                "kind": "positional_or_keyword",
+                "type": "WebsocketProgramAccountOptions",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "on_update",
+                "kind": "positional_or_keyword",
+                "type": "Optional[UpdateCallback]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "decode",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Callable[[bytes], T]]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "resub_timeout_ms",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, subscription_name: str, program: Program, options: WebsocketProgramAccountOptions, on_update: Optional[UpdateCallback], decode: Optional[Callable[[bytes], T]] = None, resub_timeout_ms: Optional[int] = None)"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "subscribe_ws",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.accounts.ws.user",
+    "path": "accounts/ws/user.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "WebsocketUserAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "get_user_account_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[UserAccount]]"
+            },
+            "signature": "(self) -> Optional[DataAndSlot[UserAccount]]"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.accounts.ws.user_stats",
+    "path": "accounts/ws/user_stats.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "WebsocketUserStatsAccountSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "get_user_stats_account_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DataAndSlot[UserStatsAccount]]"
+            },
+            "signature": "(self) -> Optional[DataAndSlot[UserStatsAccount]]"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.address_lookup_table",
+    "path": "address_lookup_table.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "LOOKUP_TABLE_META_SIZE"
+      }
+    ],
+    "functions": [
+      {
+        "name": "decode_address_lookup_table",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "pubkey",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "data",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(pubkey: Pubkey, data: bytes)"
+      },
+      {
+        "name": "get_address_lookup_table",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "connection",
+            "kind": "positional_or_keyword",
+            "type": "AsyncClient",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "pubkey",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "AddressLookupTableAccount"
+        },
+        "signature": "(connection: AsyncClient, pubkey: Pubkey) -> AddressLookupTableAccount"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.addresses",
+    "path": "addresses.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "get_drift_client_signer_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey) -> Pubkey"
+      },
+      {
+        "name": "get_high_leverage_mode_config_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey) -> Pubkey"
+      },
+      {
+        "name": "get_if_rebalance_config_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "in_market_index",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "out_market_index",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey, in_market_index: int, out_market_index: int) -> Pubkey"
+      },
+      {
+        "name": "get_insurance_fund_stake_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "authority",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "spot_market_index",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey, authority: Pubkey, spot_market_index: int) -> Pubkey"
+      },
+      {
+        "name": "get_insurance_fund_vault_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "spot_market_index",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey, spot_market_index: int) -> Pubkey"
+      },
+      {
+        "name": "get_perp_market_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "market_index",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey, market_index: int) -> Pubkey"
+      },
+      {
+        "name": "get_phoenix_fulfillment_config_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey, market: Pubkey) -> Pubkey"
+      },
+      {
+        "name": "get_prelaunch_oracle_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "market_index",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey, market_index: int) -> Pubkey"
+      },
+      {
+        "name": "get_protected_maker_mode_config_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey) -> Pubkey"
+      },
+      {
+        "name": "get_rfq_user_account_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "user_account_public_key",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey, user_account_public_key: Pubkey) -> Pubkey"
+      },
+      {
+        "name": "get_sequencer_public_key_and_bump",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "payer",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "subaccount_id",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "tuple[Pubkey, int]"
+        },
+        "signature": "(program_id: Pubkey, payer: Pubkey, subaccount_id: int) -> tuple[Pubkey, int]"
+      },
+      {
+        "name": "get_serum_fulfillment_config_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey, market: Pubkey) -> Pubkey"
+      },
+      {
+        "name": "get_serum_open_orders_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey, market: Pubkey) -> Pubkey"
+      },
+      {
+        "name": "get_serum_signer_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "nonce",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey, market: Pubkey, nonce: int) -> Pubkey"
+      },
+      {
+        "name": "get_signed_msg_user_account_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "authority",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey, authority: Pubkey) -> Pubkey"
+      },
+      {
+        "name": "get_spot_market_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "spot_market_index",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey, spot_market_index: int) -> Pubkey"
+      },
+      {
+        "name": "get_spot_market_vault_authority_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "spot_market_index",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey, spot_market_index: int) -> Pubkey"
+      },
+      {
+        "name": "get_spot_market_vault_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "spot_market_index",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey, spot_market_index: int) -> Pubkey"
+      },
+      {
+        "name": "get_state_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey) -> Pubkey"
+      },
+      {
+        "name": "get_user_account_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "authority",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "sub_account_id",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": false,
+            "default": "0"
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey, authority: Pubkey, sub_account_id = 0) -> Pubkey"
+      },
+      {
+        "name": "get_user_stats_account_public_key",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program_id",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "authority",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(program_id: Pubkey, authority: Pubkey) -> Pubkey"
+      },
+      {
+        "name": "int_to_le_bytes",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "a",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(a: int)"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.admin",
+    "path": "admin.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "Admin",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "get_settle_expired_market_pools_to_revenue_pool_ix",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int)"
+          },
+          {
+            "name": "initialize",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "usdc_mint",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "admin_controls_prices",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "tuple[Signature, Signature]"
+            },
+            "signature": "(self, usdc_mint: Pubkey, admin_controls_prices: bool) -> tuple[Signature, Signature]"
+          },
+          {
+            "name": "initialize_perp_market",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "price_oracle",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "base_asset_reserve",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "quote_asset_reserve",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "periodicity",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "peg_multiplier",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "PEG_PRECISION"
+              },
+              {
+                "name": "oracle_source",
+                "kind": "positional_or_keyword",
+                "type": "OracleSource",
+                "required": false,
+                "default": "OracleSource.Pyth()"
+              },
+              {
+                "name": "contract_tier",
+                "kind": "positional_or_keyword",
+                "type": "ContractTier",
+                "required": false,
+                "default": "ContractTier.Speculative()"
+              },
+              {
+                "name": "margin_ratio_initial",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "2000"
+              },
+              {
+                "name": "margin_ratio_maintenance",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "500"
+              },
+              {
+                "name": "liquidator_fee",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "if_liquidator_fee",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "10000"
+              },
+              {
+                "name": "imf_factor",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "active_status",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "True"
+              },
+              {
+                "name": "base_spread",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "max_spread",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "142500"
+              },
+              {
+                "name": "max_open_interest",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "max_revenue_withdraw_per_period",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "quote_max_insurance",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "order_step_size",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "BASE_PRECISION // 10000"
+              },
+              {
+                "name": "order_tick_size",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "PRICE_PRECISION // 100000"
+              },
+              {
+                "name": "min_order_size",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "BASE_PRECISION // 10000"
+              },
+              {
+                "name": "concentration_coef_scale",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "1"
+              },
+              {
+                "name": "curve_update_intensity",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "amm_jit_intensity",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "name",
+                "kind": "positional_or_keyword",
+                "type": "list",
+                "required": false,
+                "default": "[0] * 32"
+              }
+            ],
+            "returns": {
+              "type": "Signature"
+            },
+            "signature": "(self, market_index: int, price_oracle: Pubkey, base_asset_reserve: int, quote_asset_reserve: int, periodicity: int, peg_multiplier: int = PEG_PRECISION, oracle_source: OracleSource = OracleSource.Pyth(), contract_tier: ContractTier = ContractTier.Speculative(), margin_ratio_initial: int = 2000, margin_ratio_maintenance: int = 500, liquidator_fee: int = 0, if_liquidator_fee: int = 10000, imf_factor: int = 0, active_status: bool = True, base_spread: int = 0, max_spread: int = 142500, max_open_interest: int = 0, max_revenue_withdraw_per_period: int = 0, quote_max_insurance: int = 0, order_step_size: int = BASE_PRECISION // 10000, order_tick_size: int = PRICE_PRECISION // 100000, min_order_size: int = BASE_PRECISION // 10000, concentration_coef_scale: int = 1, curve_update_intensity: int = 0, amm_jit_intensity: int = 0, name: list = [0] * 32) -> Signature"
+          },
+          {
+            "name": "initialize_prelaunch_oracle",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "price",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "max_price",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, perp_market_index: int, price: Optional[int] = None, max_price: Optional[int] = None)"
+          },
+          {
+            "name": "initialize_spot_market",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "mint",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "optimal_utilization",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "SPOT_RATE_PRECISION // 2"
+              },
+              {
+                "name": "optimal_rate",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "SPOT_RATE_PRECISION"
+              },
+              {
+                "name": "max_rate",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "SPOT_RATE_PRECISION"
+              },
+              {
+                "name": "oracle",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": false,
+                "default": "Pubkey([0] * Pubkey.LENGTH)"
+              },
+              {
+                "name": "oracle_source",
+                "kind": "positional_or_keyword",
+                "type": "OracleSource",
+                "required": false,
+                "default": "OracleSource.QuoteAsset()"
+              },
+              {
+                "name": "initial_asset_weight",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "SPOT_WEIGHT_PRECISION"
+              },
+              {
+                "name": "maintenance_asset_weight",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "SPOT_WEIGHT_PRECISION"
+              },
+              {
+                "name": "initial_liability_weight",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "SPOT_WEIGHT_PRECISION"
+              },
+              {
+                "name": "maintenance_liability_weight",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "SPOT_WEIGHT_PRECISION"
+              },
+              {
+                "name": "imf_factor",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "liquidator_fee",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "if_liquidation_fee",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "scale_initial_asset_weight_start",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "withdraw_guard_threshold",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "order_tick_size",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "1"
+              },
+              {
+                "name": "order_step_size",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "1"
+              },
+              {
+                "name": "if_total_factor",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "asset_tier",
+                "kind": "positional_or_keyword",
+                "type": "AssetTier",
+                "required": false,
+                "default": "AssetTier.COLLATERAL()"
+              },
+              {
+                "name": "active_status",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "True"
+              },
+              {
+                "name": "name",
+                "kind": "positional_or_keyword",
+                "type": "list",
+                "required": false,
+                "default": "[0] * 32"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, mint: Pubkey, optimal_utilization: int = SPOT_RATE_PRECISION // 2, optimal_rate: int = SPOT_RATE_PRECISION, max_rate: int = SPOT_RATE_PRECISION, oracle: Pubkey = Pubkey([0] * Pubkey.LENGTH), oracle_source: OracleSource = OracleSource.QuoteAsset(), initial_asset_weight: int = SPOT_WEIGHT_PRECISION, maintenance_asset_weight: int = SPOT_WEIGHT_PRECISION, initial_liability_weight: int = SPOT_WEIGHT_PRECISION, maintenance_liability_weight: int = SPOT_WEIGHT_PRECISION, imf_factor: int = 0, liquidator_fee: int = 0, if_liquidation_fee: int = 0, scale_initial_asset_weight_start: int = 0, withdraw_guard_threshold: int = 0, order_tick_size: int = 1, order_step_size: int = 1, if_total_factor: int = 0, asset_tier: AssetTier = AssetTier.COLLATERAL(), active_status: bool = True, name: list = [0] * 32)"
+          },
+          {
+            "name": "repeg_curve",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "peg",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, peg: int, perp_market_index: int)"
+          },
+          {
+            "name": "repeg_curve_ix",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "peg",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, peg: int, perp_market_index: int)"
+          },
+          {
+            "name": "settle_expired_market_pools_to_revenue_pool",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int)"
+          },
+          {
+            "name": "update_initial_percent_to_liquidate",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "initial_percent_to_liquidate",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Signature"
+            },
+            "signature": "(self, initial_percent_to_liquidate: int) -> Signature"
+          },
+          {
+            "name": "update_k",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sqrt_k",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, sqrt_k: int, perp_market_index: int)"
+          },
+          {
+            "name": "update_k_ix",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sqrt_k",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, sqrt_k: int, perp_market_index: int)"
+          },
+          {
+            "name": "update_lp_cooldown_time",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "duration",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, duration: int)"
+          },
+          {
+            "name": "update_lp_cooldown_time",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "duration",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, duration: int)"
+          },
+          {
+            "name": "update_oracle_guard_rails",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_guard_rails",
+                "kind": "positional_or_keyword",
+                "type": "OracleGuardRails",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, oracle_guard_rails: OracleGuardRails)"
+          },
+          {
+            "name": "update_perp_auction_duration",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "min_duration",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, min_duration: int)"
+          },
+          {
+            "name": "update_perp_market_base_spread",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "base_spread",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int, base_spread: int)"
+          },
+          {
+            "name": "update_perp_market_concentration_scale",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "concentration_scale",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int, concentration_scale: int)"
+          },
+          {
+            "name": "update_perp_market_contract_tier",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "contract_type",
+                "kind": "positional_or_keyword",
+                "type": "ContractTier",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int, contract_type: ContractTier)"
+          },
+          {
+            "name": "update_perp_market_curve_update_intensity",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "curve_update_intensity",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int, curve_update_intensity: int)"
+          },
+          {
+            "name": "update_perp_market_expiry",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "expiry_ts",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int, expiry_ts: int)"
+          },
+          {
+            "name": "update_perp_market_max_fill_reserve_fraction",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "max_fill_reserve_fraction",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int, max_fill_reserve_fraction: int)"
+          },
+          {
+            "name": "update_perp_market_max_imbalances",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "unrealized_max_imbalance",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "max_revenue_withdraw_per_period",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "quote_max_insurance",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index, unrealized_max_imbalance, max_revenue_withdraw_per_period, quote_max_insurance)"
+          },
+          {
+            "name": "update_perp_market_max_spread",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "max_spread",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int, max_spread: int)"
+          },
+          {
+            "name": "update_perp_market_oracle",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_source",
+                "kind": "positional_or_keyword",
+                "type": "OracleSource",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int, oracle: Pubkey, oracle_source: OracleSource)"
+          },
+          {
+            "name": "update_perp_market_status",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_status",
+                "kind": "positional_or_keyword",
+                "type": "MarketStatus",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int, market_status: MarketStatus)"
+          },
+          {
+            "name": "update_perp_market_step_size_and_tick_size",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "step_size",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "tick_size",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int, step_size: int, tick_size: int)"
+          },
+          {
+            "name": "update_prelaunch_oracle_params",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "price",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "max_price",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, perp_market_index: int, price: Optional[int] = None, max_price: Optional[int] = None)"
+          },
+          {
+            "name": "update_spot_market_expiry",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "expiry_ts",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_market_index: int, expiry_ts: int)"
+          },
+          {
+            "name": "update_spot_market_oracle",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_source",
+                "kind": "positional_or_keyword",
+                "type": "OracleSource",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int, oracle: Pubkey, oracle_source: OracleSource)"
+          },
+          {
+            "name": "update_state_settlement_duration",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "settlement_duration",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, settlement_duration: int)"
+          },
+          {
+            "name": "update_update_insurance_fund_unstaking_period",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "insurance_fund_unstaking_period",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_market_index: int, insurance_fund_unstaking_period: int)"
+          },
+          {
+            "name": "update_withdraw_guard_threshold",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "withdraw_guard_threshold",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_market_index: int, withdraw_guard_threshold: int)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.auction_subscriber.auction_subscriber",
+    "path": "auction_subscriber/auction_subscriber.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "AuctionEvents",
+        "docstring": "Subclass to explicitly declare the on_account_update event\nboth in __events__ and as a typed attribute.",
+        "methods": []
+      },
+      {
+        "name": "AuctionSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "config",
+                "kind": "positional_or_keyword",
+                "type": "AuctionSubscriberConfig",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, config: AuctionSubscriberConfig)"
+          },
+          {
+            "name": "on_update",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "account_pubkey",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "data",
+                "kind": "positional_or_keyword",
+                "type": "DataAndSlot[UserAccount]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, account_pubkey: str, data: DataAndSlot[UserAccount])"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.auction_subscriber.grpc_auction_subscriber",
+    "path": "auction_subscriber/grpc_auction_subscriber.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "GrpcAuctionEvents",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "GrpcAuctionSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "config",
+                "kind": "positional_or_keyword",
+                "type": "GrpcAuctionSubscriberConfig",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, config: GrpcAuctionSubscriberConfig)"
+          },
+          {
+            "name": "on_update",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "account_pubkey",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "data",
+                "kind": "positional_or_keyword",
+                "type": "DataAndSlot[UserAccount]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, account_pubkey: str, data: DataAndSlot[UserAccount])"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.auction_subscriber.types",
+    "path": "auction_subscriber/types.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "AuctionSubscriberConfig",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "drift_client",
+                "kind": "positional_or_keyword",
+                "type": "DriftClient",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "commitment",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Commitment]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "resub_timeout_ms",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, drift_client: DriftClient, commitment: Optional[Commitment] = None, resub_timeout_ms: Optional[int] = None)"
+          }
+        ]
+      },
+      {
+        "name": "GrpcAuctionSubscriberConfig",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "drift_client",
+                "kind": "positional_or_keyword",
+                "type": "DriftClient",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "grpc_config",
+                "kind": "positional_or_keyword",
+                "type": "GrpcConfig",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "commitment",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Commitment]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, drift_client: DriftClient, grpc_config: GrpcConfig, commitment: Optional[Commitment] = None)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.constants.config",
+    "path": "constants/config.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "DEVNET_SEQUENCER_PROGRAM_ID"
+      },
+      {
+        "name": "DRIFT_PROGRAM_ID"
+      },
+      {
+        "name": "SEQUENCER_PROGRAM_ID"
+      },
+      {
+        "name": "T"
+      },
+      {
+        "name": "VAULT_PROGRAM_ID"
+      }
+    ],
+    "functions": [
+      {
+        "name": "chunks",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "array",
+            "kind": "positional_or_keyword",
+            "type": "List[T]",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "size",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "List[List[T]]"
+        },
+        "signature": "(array: List[T], size: int) -> List[List[T]]"
+      },
+      {
+        "name": "decode_account",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "decoded_data",
+            "kind": "positional_or_keyword",
+            "type": "bytes | str",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(decoded_data: bytes | str, program)"
+      },
+      {
+        "name": "find_all_market_and_oracles",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Tuple[list[DataAndSlot[PerpMarketAccount]], list[DataAndSlot[SpotMarketAccount]], list[FullOracleWrapper]]"
+        },
+        "signature": "(program: Program) -> Tuple[list[DataAndSlot[PerpMarketAccount]], list[DataAndSlot[SpotMarketAccount]], list[FullOracleWrapper]]"
+      },
+      {
+        "name": "find_all_market_and_oracles_no_data_and_slots",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Tuple[list[int], list[int], list[OracleInfo]]"
+        },
+        "signature": "(program: Program) -> Tuple[list[int], list[int], list[OracleInfo]]"
+      },
+      {
+        "name": "find_market_config_by_index",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market_configs",
+            "kind": "positional_or_keyword",
+            "type": "list[Union[SpotMarketConfig, PerpMarketConfig]]",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "market_index",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Optional[Union[SpotMarketConfig, PerpMarketConfig]]"
+        },
+        "signature": "(market_configs: list[Union[SpotMarketConfig, PerpMarketConfig]], market_index: int) -> Optional[Union[SpotMarketConfig, PerpMarketConfig]]"
+      },
+      {
+        "name": "get_chunked_account_infos",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "connection",
+            "kind": "positional_or_keyword",
+            "type": "AsyncClient",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "pubkeys",
+            "kind": "positional_or_keyword",
+            "type": "List[Pubkey]",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "chunk_size",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": false,
+            "default": "75"
+          }
+        ],
+        "returns": {
+          "type": "GetMultipleAccountsResp"
+        },
+        "signature": "(connection: AsyncClient, pubkeys: List[Pubkey], chunk_size: int = 75) -> GetMultipleAccountsResp"
+      },
+      {
+        "name": "get_markets_and_oracles",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "env",
+            "kind": "positional_or_keyword",
+            "type": "DriftEnv",
+            "required": false,
+            "default": "'mainnet'"
+          },
+          {
+            "name": "perp_markets",
+            "kind": "positional_or_keyword",
+            "type": "Optional[Sequence[int]]",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "spot_markets",
+            "kind": "positional_or_keyword",
+            "type": "Optional[Sequence[int]]",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(env: DriftEnv = 'mainnet', perp_markets: Optional[Sequence[int]] = None, spot_markets: Optional[Sequence[int]] = None)"
+      }
+    ],
+    "classes": [
+      {
+        "name": "Config",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.constants.numeric_constants",
+    "path": "constants/numeric_constants.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "AMM_RESERVE_PRECISION"
+      },
+      {
+        "name": "AMM_TIMES_PEG_TO_QUOTE_PRECISION_RATIO"
+      },
+      {
+        "name": "AMM_TO_QUOTE_PRECISION_RATIO"
+      },
+      {
+        "name": "BASE_PRECISION"
+      },
+      {
+        "name": "BID_ASK_SPREAD_PRECISION"
+      },
+      {
+        "name": "CONCENTRATION_PRECISION"
+      },
+      {
+        "name": "DEFAULT_LARGE_BID_ASK_FACTOR"
+      },
+      {
+        "name": "DEFAULT_REVENUE_SINCE_LAST_FUNDING_SPREAD_RETREAT"
+      },
+      {
+        "name": "EPOCH_DURATION"
+      },
+      {
+        "name": "FEE_DENOMINATOR"
+      },
+      {
+        "name": "FEE_PERCENTAGE_DENOMINATOR"
+      },
+      {
+        "name": "FIFTY_MILLION_QUOTE"
+      },
+      {
+        "name": "FIVE_HUNDRED_THOUSAND"
+      },
+      {
+        "name": "FIVE_MILLION_QUOTE"
+      },
+      {
+        "name": "FIVE_MINUTE"
+      },
+      {
+        "name": "FIVE_THOUSAND"
+      },
+      {
+        "name": "FUEL_START_TS"
+      },
+      {
+        "name": "FUEL_WINDOW"
+      },
+      {
+        "name": "FUNDING_RATE_BUFFER"
+      },
+      {
+        "name": "FUNDING_RATE_OFFSET_DENOMINATOR"
+      },
+      {
+        "name": "FUNDING_RATE_PRECISION"
+      },
+      {
+        "name": "FUNDING_RATE_TO_QUOTE_PRECISION_PRECISION_RATIO"
+      },
+      {
+        "name": "GOV_SPOT_MARKET_INDEX"
+      },
+      {
+        "name": "IF_FACTOR_PRECISION"
+      },
+      {
+        "name": "K_BPS_DECREASE_MAX"
+      },
+      {
+        "name": "K_BPS_INCREASE_MAX"
+      },
+      {
+        "name": "K_BPS_UPDATE_SCALE"
+      },
+      {
+        "name": "LIQUIDATION_FEE_PRECISION"
+      },
+      {
+        "name": "LIQUIDATION_FEE_TO_MARGIN_PRECISION_RATIO"
+      },
+      {
+        "name": "LIQUIDATION_PCT_PRECISION"
+      },
+      {
+        "name": "LP_FEE_SLICE_DENOMINATOR"
+      },
+      {
+        "name": "LP_FEE_SLICE_NUMERATOR"
+      },
+      {
+        "name": "MARGIN_PRECISION"
+      },
+      {
+        "name": "MAXIMUM_MARGIN_RATIO"
+      },
+      {
+        "name": "MAX_APR_PER_REVENUE_SETTLE_PRECISION"
+      },
+      {
+        "name": "MAX_APR_PER_REVENUE_SETTLE_TO_INSURANCE_FUND_VAULT"
+      },
+      {
+        "name": "MAX_BID_ASK_INVENTORY_SKEW_FACTOR"
+      },
+      {
+        "name": "MAX_CONCENTRATION_COEFFICIENT"
+      },
+      {
+        "name": "MAX_LIQUIDATION_SLIPPAGE"
+      },
+      {
+        "name": "MAX_LIQUIDATION_SLIPPAGE_U128"
+      },
+      {
+        "name": "MAX_MARK_TWAP_DIVERGENCE"
+      },
+      {
+        "name": "MAX_PREDICTION_PRICE"
+      },
+      {
+        "name": "MAX_REFERRER_REWARD_EPOCH_UPPER_BOUND"
+      },
+      {
+        "name": "MINIMUM_MARGIN_RATIO"
+      },
+      {
+        "name": "ONE_BILLION"
+      },
+      {
+        "name": "ONE_BPS_DENOMINATOR"
+      },
+      {
+        "name": "ONE_HOUR"
+      },
+      {
+        "name": "ONE_HOUR_I128"
+      },
+      {
+        "name": "ONE_HUNDRED_MILLION"
+      },
+      {
+        "name": "ONE_HUNDRED_MILLION_QUOTE"
+      },
+      {
+        "name": "ONE_HUNDRED_THOUSAND"
+      },
+      {
+        "name": "ONE_HUNDRED_THOUSAND_QUOTE"
+      },
+      {
+        "name": "ONE_MILLION"
+      },
+      {
+        "name": "ONE_MILLION_QUOTE"
+      },
+      {
+        "name": "ONE_THOUSAND"
+      },
+      {
+        "name": "ONE_THOUSAND_QUOTE"
+      },
+      {
+        "name": "ONE_YEAR"
+      },
+      {
+        "name": "OPEN_ORDER_MARGIN_REQUIREMENT"
+      },
+      {
+        "name": "PEG_BPS_DECREASE_MAX"
+      },
+      {
+        "name": "PEG_BPS_INCREASE_MAX"
+      },
+      {
+        "name": "PEG_BPS_UPDATE_SCALE"
+      },
+      {
+        "name": "PEG_PRECISION"
+      },
+      {
+        "name": "PERCENTAGE_PRECISION"
+      },
+      {
+        "name": "PERCENTAGE_PRECISION_EXP"
+      },
+      {
+        "name": "PERP_DECIMALS"
+      },
+      {
+        "name": "PRICE_DIV_PEG"
+      },
+      {
+        "name": "PRICE_PRECISION"
+      },
+      {
+        "name": "PRICE_TIMES_AMM_TO_QUOTE_PRECISION_RATIO"
+      },
+      {
+        "name": "PRICE_TO_PEG_PRECISION_RATIO"
+      },
+      {
+        "name": "PRICE_TO_QUOTE_PRECISION_RATIO"
+      },
+      {
+        "name": "QUOTE_PRECISION"
+      },
+      {
+        "name": "QUOTE_SPOT_MARKET_INDEX"
+      },
+      {
+        "name": "QUOTE_TO_BASE_AMT_FUNDING_PRECISION"
+      },
+      {
+        "name": "SHARE_OF_FEES_ALLOCATED_TO_CLEARING_HOUSE_DENOMINATOR"
+      },
+      {
+        "name": "SHARE_OF_FEES_ALLOCATED_TO_CLEARING_HOUSE_NUMERATOR"
+      },
+      {
+        "name": "SHARE_OF_IF_ESCROW_ALLOCATED_TO_PROTOCOL_DENOMINATOR"
+      },
+      {
+        "name": "SHARE_OF_IF_ESCROW_ALLOCATED_TO_PROTOCOL_NUMERATOR"
+      },
+      {
+        "name": "SHARE_OF_REVENUE_ALLOCATED_TO_INSURANCE_FUND_VAULT_DENOMINATOR"
+      },
+      {
+        "name": "SHARE_OF_REVENUE_ALLOCATED_TO_INSURANCE_FUND_VAULT_NUMERATOR"
+      },
+      {
+        "name": "SPOT_BALANCE_PRECISION"
+      },
+      {
+        "name": "SPOT_CUMULATIVE_INTEREST_PRECISION"
+      },
+      {
+        "name": "SPOT_IMF_PRECISION"
+      },
+      {
+        "name": "SPOT_MARKET_CUMULATIVE_INTEREST_PRECISION"
+      },
+      {
+        "name": "SPOT_MARKET_CUMULATIVE_INTEREST_PRECISION_EXP"
+      },
+      {
+        "name": "SPOT_MARKET_WEIGHT_PRECISION"
+      },
+      {
+        "name": "SPOT_RATE_PRECISION"
+      },
+      {
+        "name": "SPOT_UTILIZATION_PRECISION"
+      },
+      {
+        "name": "SPOT_WEIGHT_PRECISION"
+      },
+      {
+        "name": "SWB_PRECISION"
+      },
+      {
+        "name": "TEN_BILLION"
+      },
+      {
+        "name": "TEN_BPS"
+      },
+      {
+        "name": "TEN_MILLION"
+      },
+      {
+        "name": "TEN_MILLION_QUOTE"
+      },
+      {
+        "name": "TEN_THOUSAND"
+      },
+      {
+        "name": "TEN_THOUSAND_QUOTE"
+      },
+      {
+        "name": "TWENTY_FIVE_THOUSAND_QUOTE"
+      },
+      {
+        "name": "TWENTY_FOUR_HOUR"
+      },
+      {
+        "name": "TWO_HUNDRED_FIFTY_THOUSAND_QUOTE"
+      },
+      {
+        "name": "UPDATE_K_ALLOWED_PRICE_CHANGE"
+      }
+    ],
+    "functions": [],
+    "classes": []
+  },
+  {
+    "module": "driftpy.constants.perp_markets",
+    "path": "constants/perp_markets.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "PerpMarketConfig",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.constants.spot_markets",
+    "path": "constants/spot_markets.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "WRAPPED_SOL_MINT"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "SpotMarketConfig",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.decode.pull_oracle",
+    "path": "decode/pull_oracle.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "decode_pull_oracle",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "buffer",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "PriceUpdateV2"
+        },
+        "signature": "(buffer: bytes) -> PriceUpdateV2"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.decode.signed_msg_order",
+    "path": "decode/signed_msg_order.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "decode_order_params",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "buffer",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "OrderParams"
+        },
+        "signature": "(buffer: bytes) -> OrderParams"
+      },
+      {
+        "name": "decode_order_params_with_size",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "buffer",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "tuple[OrderParams, int]"
+        },
+        "signature": "(buffer: bytes) -> tuple[OrderParams, int]"
+      },
+      {
+        "name": "decode_signed_msg_order_params_message",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "buffer",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "SignedMsgOrderParamsMessage"
+        },
+        "signature": "(buffer: bytes) -> SignedMsgOrderParamsMessage"
+      },
+      {
+        "name": "decode_signed_msg_trigger_params",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "buffer",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "SignedMsgTriggerOrderParams"
+        },
+        "signature": "(buffer: bytes) -> SignedMsgTriggerOrderParams"
+      },
+      {
+        "name": "read_bigint64le",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "buffer",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "offset",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "signed",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(buffer, offset, signed)"
+      },
+      {
+        "name": "read_bool",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "byte",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(byte: int) -> bool"
+      },
+      {
+        "name": "read_bytes",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "buffer",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "offset",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "size",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(buffer, offset, size)"
+      },
+      {
+        "name": "read_int32_le",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "buffer",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "offset",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "signed",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(buffer, offset, signed)"
+      },
+      {
+        "name": "read_uint16_le",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "buffer",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "offset",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(buffer, offset)"
+      },
+      {
+        "name": "read_uint8",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "buffer",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "offset",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(buffer, offset)"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.decode.user",
+    "path": "decode/user.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "decode_user",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "buffer",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "UserAccount"
+        },
+        "signature": "(buffer: bytes) -> UserAccount"
+      },
+      {
+        "name": "read_bigint64le",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "buffer",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "offset",
+            "kind": "positional_or_keyword",
+            "type": "Literal",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "signed",
+            "kind": "positional_or_keyword",
+            "type": "bool",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(buffer, offset: Literal, signed: bool)"
+      },
+      {
+        "name": "read_int32_le",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "buffer",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "offset",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "signed",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(buffer, offset, signed)"
+      },
+      {
+        "name": "read_uint16_le",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "buffer",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "offset",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(buffer, offset)"
+      },
+      {
+        "name": "read_uint8",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "buffer",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "offset",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(buffer, offset)"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.decode.user_stat",
+    "path": "decode/user_stat.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "decode_user_stat",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "buffer",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "UserStatsAccount"
+        },
+        "signature": "(buffer: bytes) -> UserStatsAccount"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.decode.utils",
+    "path": "decode/utils.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "decode_name",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "bytes_list",
+            "kind": "positional_or_keyword",
+            "type": "list[int]",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(bytes_list: list[int])"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.dlob.client_types",
+    "path": "dlob/client_types.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "DLOBClientConfig",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "DLOBSource",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "get_DLOB",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "DLOB"
+            },
+            "signature": "(self, slot: int) -> DLOB"
+          }
+        ]
+      },
+      {
+        "name": "SlotSource",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "get_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self) -> int"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.dlob.dlob",
+    "path": "dlob/dlob.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "SUPPORTED_ORDER_TYPES"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "DLOB",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "add_order_list",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, market_type: str, market_index: int) -> None"
+          },
+          {
+            "name": "clear",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "delete",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "on_delete",
+                "kind": "positional_or_keyword",
+                "type": "Optional[OrderBookCallback]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order: Order, user_account: Pubkey, slot: int, on_delete: Optional[OrderBookCallback] = None)"
+          },
+          {
+            "name": "determine_maker_and_taker",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "ask",
+                "kind": "positional_or_keyword",
+                "type": "DLOBNode",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "bid",
+                "kind": "positional_or_keyword",
+                "type": "DLOBNode",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Union[Tuple[DLOBNode, DLOBNode], None]"
+            },
+            "signature": "(self, ask: DLOBNode, bid: DLOBNode) -> Union[Tuple[DLOBNode, DLOBNode], None]"
+          },
+          {
+            "name": "estimate_fill_with_exact_base_amount",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "base_amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_direction",
+                "kind": "positional_or_keyword",
+                "type": "PositionDirection",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self, market_index: int, market_type: MarketType, base_amount: int, order_direction: PositionDirection, slot: int, oracle_price_data: OraclePriceData) -> int"
+          },
+          {
+            "name": "find_crossing_resting_limit_orders",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "List[NodeToFill]"
+            },
+            "signature": "(self, market_index: int, slot: int, market_type: MarketType, oracle_price_data: OraclePriceData) -> List[NodeToFill]"
+          },
+          {
+            "name": "find_expired_nodes_to_fill",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "ts",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "List[NodeToFill]"
+            },
+            "signature": "(self, market_index: int, ts: int, market_type: MarketType) -> List[NodeToFill]"
+          },
+          {
+            "name": "find_jit_auction_nodes_to_fill",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "List[NodeToFill]"
+            },
+            "signature": "(self, market_index: int, slot: int, oracle_price_data: OraclePriceData, market_type: MarketType) -> List[NodeToFill]"
+          },
+          {
+            "name": "find_nodes_crossing_fallback_liquidity",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "node_generator",
+                "kind": "positional_or_keyword",
+                "type": "Generator[DLOBNode, None, None]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "does_cross",
+                "kind": "positional_or_keyword",
+                "type": "Callable[[Optional[int]], bool]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "min_auction_duration",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "List[NodeToFill]"
+            },
+            "signature": "(self, market_type: MarketType, slot: int, oracle_price_data: OraclePriceData, node_generator: Generator[DLOBNode, None, None], does_cross: Callable[[Optional[int]], bool], min_auction_duration: int) -> List[NodeToFill]"
+          },
+          {
+            "name": "find_nodes_to_fill",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "ts",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "state_account",
+                "kind": "positional_or_keyword",
+                "type": "StateAccount",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_account",
+                "kind": "positional_or_keyword",
+                "type": "Union[PerpMarketAccount, SpotMarketAccount]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "fallback_bid",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "fallback_ask",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "List[NodeToFill]"
+            },
+            "signature": "(self, market_index: int, slot: int, ts: int, market_type: MarketType, oracle_price_data: OraclePriceData, state_account: StateAccount, market_account: Union[PerpMarketAccount, SpotMarketAccount], fallback_bid: Optional[int] = None, fallback_ask: Optional[int] = None) -> List[NodeToFill]"
+          },
+          {
+            "name": "find_nodes_to_trigger",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "state_account",
+                "kind": "positional_or_keyword",
+                "type": "StateAccount",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "list[NodeToTrigger]"
+            },
+            "signature": "(self, market_index: int, oracle_price: int, market_type: MarketType, state_account: StateAccount) -> list[NodeToTrigger]"
+          },
+          {
+            "name": "find_resting_limit_order_nodes_to_fill",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "is_amm_paused",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "min_auction_duration",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "maker_rebate_numerator",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "maker_rebate_denominator",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "fallback_ask",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "fallback_bid",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "List[NodeToFill]"
+            },
+            "signature": "(self, market_index: int, slot: int, market_type: MarketType, oracle_price_data: OraclePriceData, is_amm_paused: bool, min_auction_duration: int, maker_rebate_numerator: int, maker_rebate_denominator: int, fallback_ask: Optional[int] = None, fallback_bid: Optional[int] = None) -> List[NodeToFill]"
+          },
+          {
+            "name": "find_taking_nodes_crossing_maker_nodes",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "taker_node_generator",
+                "kind": "positional_or_keyword",
+                "type": "Generator[DLOBNode, None, None]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "maker_node_generator_fn",
+                "kind": "positional_or_keyword",
+                "type": "Callable[[int, int, MarketType, OraclePriceData], Generator[DLOBNode, None, None]]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "does_cross",
+                "kind": "positional_or_keyword",
+                "type": "Callable[[int, int], bool]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "List[NodeToFill]"
+            },
+            "signature": "(self, market_index: int, slot: int, market_type: MarketType, oracle_price_data: OraclePriceData, taker_node_generator: Generator[DLOBNode, None, None], maker_node_generator_fn: Callable[[int, int, MarketType, OraclePriceData], Generator[DLOBNode, None, None]], does_cross: Callable[[int, int], bool]) -> List[NodeToFill]"
+          },
+          {
+            "name": "find_taking_nodes_to_fill",
+            "is_async": false,
+            "docstring": "THIS NEEDS UNIT TESTS BEFORE BEING USED IN PROD",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "is_amm_paused",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "min_auction_duration",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "fallback_ask",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "fallback_bid",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "List[NodeToFill]"
+            },
+            "signature": "(self, market_index: int, slot: int, market_type: MarketType, oracle_price_data: OraclePriceData, is_amm_paused: bool, min_auction_duration: int, fallback_ask: Optional[int] = None, fallback_bid: Optional[int] = None) -> List[NodeToFill]"
+          },
+          {
+            "name": "get_asks",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "fallback_ask",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "Generator[DLOBNode, None, None]"
+            },
+            "signature": "(self, market_index: int, slot: int, market_type: MarketType, oracle_price_data: OraclePriceData, fallback_ask: Optional[int] = None) -> Generator[DLOBNode, None, None]"
+          },
+          {
+            "name": "get_best_ask",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self, market_index: int, slot: int, market_type: MarketType, oracle_price_data: OraclePriceData) -> int"
+          },
+          {
+            "name": "get_best_bid",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self, market_index: int, slot: int, market_type: MarketType, oracle_price_data: OraclePriceData) -> int"
+          },
+          {
+            "name": "get_bids",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "fallback_bid",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "Generator[DLOBNode, None, None]"
+            },
+            "signature": "(self, market_index: int, slot: int, market_type: int, oracle_price_data: OraclePriceData, fallback_bid: Optional[int] = None) -> Generator[DLOBNode, None, None]"
+          },
+          {
+            "name": "get_l2",
+            "is_async": false,
+            "docstring": "get an l2 view of the orderbook for a given market",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "depth",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "fallback_l2_generators",
+                "kind": "positional_or_keyword",
+                "type": "List[L2OrderBookGenerator]",
+                "required": false,
+                "default": "[]"
+              }
+            ],
+            "returns": {
+              "type": "L2OrderBook"
+            },
+            "signature": "(self, market_index: int, market_type: MarketType, slot: int, oracle_price_data: OraclePriceData, depth: int, fallback_l2_generators: List[L2OrderBookGenerator] = []) -> L2OrderBook"
+          },
+          {
+            "name": "get_l3",
+            "is_async": false,
+            "docstring": "get an l3 view of the orderbook for a given market",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "L3OrderBook"
+            },
+            "signature": "(self, market_index: int, market_type: MarketType, slot: int, oracle_price_data: OraclePriceData) -> L3OrderBook"
+          },
+          {
+            "name": "get_list_for_order",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[NodeList]"
+            },
+            "signature": "(self, order: Order, slot: int) -> Optional[NodeList]"
+          },
+          {
+            "name": "get_order",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[Order]"
+            },
+            "signature": "(self, order_id: int, user_account: Pubkey) -> Optional[Order]"
+          },
+          {
+            "name": "get_resting_limit_asks",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "filter_fcn",
+                "kind": "positional_or_keyword",
+                "type": "Optional[DLOBFilterFcn]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "Generator[DLOBNode, None, None]"
+            },
+            "signature": "(self, market_index: int, slot: int, market_type: MarketType, oracle_price_data: OraclePriceData, filter_fcn: Optional[DLOBFilterFcn] = None) -> Generator[DLOBNode, None, None]"
+          },
+          {
+            "name": "get_resting_limit_bids",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "filter_fcn",
+                "kind": "positional_or_keyword",
+                "type": "Optional[DLOBFilterFcn]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "Generator[DLOBNode, None, None]"
+            },
+            "signature": "(self, market_index: int, slot: int, market_type: MarketType, oracle_price_data: OraclePriceData, filter_fcn: Optional[DLOBFilterFcn] = None) -> Generator[DLOBNode, None, None]"
+          },
+          {
+            "name": "get_taking_asks",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Generator[DLOBNode, None, None]"
+            },
+            "signature": "(self, market_index: int, market_type: MarketType, slot: int, oracle_price_data: OraclePriceData) -> Generator[DLOBNode, None, None]"
+          },
+          {
+            "name": "get_taking_bids",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Generator[DLOBNode, None, None]"
+            },
+            "signature": "(self, market_index: int, market_type: MarketType, slot: int, oracle_price_data: OraclePriceData) -> Generator[DLOBNode, None, None]"
+          },
+          {
+            "name": "handle_order_record",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "record",
+                "kind": "positional_or_keyword",
+                "type": "OrderRecord",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, record: OrderRecord, slot: int)"
+          },
+          {
+            "name": "init",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "init_from_usermap",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "usermap",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self, usermap, slot: int) -> bool"
+          },
+          {
+            "name": "insert_order",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "on_insert",
+                "kind": "positional_or_keyword",
+                "type": "Optional[OrderBookCallback]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order: Order, user_account: Pubkey, slot: int, on_insert: Optional[OrderBookCallback] = None)"
+          },
+          {
+            "name": "merge_nodes_to_fill",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "resting_limit_order_nodes_to_fill",
+                "kind": "positional_or_keyword",
+                "type": "List[NodeToFill]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "taking_order_nodes_to_fill",
+                "kind": "positional_or_keyword",
+                "type": "List[NodeToFill]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "List[NodeToFill]"
+            },
+            "signature": "(self, resting_limit_order_nodes_to_fill: List[NodeToFill], taking_order_nodes_to_fill: List[NodeToFill]) -> List[NodeToFill]"
+          },
+          {
+            "name": "trigger",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "on_trigger",
+                "kind": "positional_or_keyword",
+                "type": "Optional[OrderBookCallback]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order: Order, user_account: Pubkey, slot: int, on_trigger: Optional[OrderBookCallback] = None)"
+          },
+          {
+            "name": "update_order",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "cumulative_base_asset_amount_filled",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "on_update",
+                "kind": "positional_or_keyword",
+                "type": "Optional[OrderBookCallback]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order: Order, user_account: Pubkey, slot: int, cumulative_base_asset_amount_filled: int, on_update: Optional[OrderBookCallback] = None)"
+          },
+          {
+            "name": "update_resting_limit_orders",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, slot: int)"
+          }
+        ]
+      },
+      {
+        "name": "MarketNodeLists",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      },
+      {
+        "name": "NodeToFill",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "node",
+                "kind": "positional_or_keyword",
+                "type": "DLOBNode",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "maker_nodes",
+                "kind": "positional_or_keyword",
+                "type": "List[DLOBNode]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, node: DLOBNode, maker_nodes: List[DLOBNode])"
+          }
+        ]
+      },
+      {
+        "name": "NodeToTrigger",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "node",
+                "kind": "positional_or_keyword",
+                "type": "TriggerOrderNode",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, node: TriggerOrderNode)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.dlob.dlob_helpers",
+    "path": "dlob/dlob_helpers.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "get_maker_rebate",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market_type",
+            "kind": "positional_or_keyword",
+            "type": "MarketType",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "state_account",
+            "kind": "positional_or_keyword",
+            "type": "StateAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "market_account",
+            "kind": "positional_or_keyword",
+            "type": "Union[PerpMarketAccount, SpotMarketAccount]",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(market_type: MarketType, state_account: StateAccount, market_account: Union[PerpMarketAccount, SpotMarketAccount])"
+      },
+      {
+        "name": "get_node_lists",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order_lists",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(order_lists)"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.dlob.dlob_node",
+    "path": "dlob/dlob_node.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "create_node",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "node_type",
+            "kind": "positional_or_keyword",
+            "type": "NodeType",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "order",
+            "kind": "positional_or_keyword",
+            "type": "Order",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "user_account",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(node_type: NodeType, order: Order, user_account: Pubkey)"
+      }
+    ],
+    "classes": [
+      {
+        "name": "DLOBNode",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "get_price",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self, oracle_price_data: OraclePriceData, slot: int) -> int"
+          },
+          {
+            "name": "is_base_filled",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self) -> bool"
+          },
+          {
+            "name": "is_vamm_node",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self) -> bool"
+          }
+        ]
+      },
+      {
+        "name": "FloatingLimitOrderNode",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order: Order, user_account: Pubkey)"
+          },
+          {
+            "name": "get_sort_value",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self, order: Order) -> int"
+          }
+        ]
+      },
+      {
+        "name": "MarketOrderNode",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order: Order, user_account: Pubkey)"
+          },
+          {
+            "name": "get_sort_value",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self, order: Order) -> int"
+          }
+        ]
+      },
+      {
+        "name": "OrderNode",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order: Order, user_account: Pubkey)"
+          },
+          {
+            "name": "get_label",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get_price",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, oracle_price_data: OraclePriceData, slot: int)"
+          },
+          {
+            "name": "get_sort_value",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order: Order)"
+          },
+          {
+            "name": "is_base_filled",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self) -> bool"
+          },
+          {
+            "name": "is_vamm_node",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      },
+      {
+        "name": "RestingLimitOrderNode",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order: Order, user_account: Pubkey)"
+          },
+          {
+            "name": "get_sort_value",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self, order: Order) -> int"
+          }
+        ]
+      },
+      {
+        "name": "TakingLimitOrderNode",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order: Order, user_account: Pubkey)"
+          },
+          {
+            "name": "get_sort_value",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self, order: Order) -> int"
+          }
+        ]
+      },
+      {
+        "name": "TriggerOrderNode",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order: Order, user_account: Pubkey)"
+          },
+          {
+            "name": "get_sort_value",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self, order: Order) -> int"
+          }
+        ]
+      },
+      {
+        "name": "VAMMNode",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "price",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, price: int)"
+          },
+          {
+            "name": "get_price",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_price_data",
+                "kind": "positional_or_keyword",
+                "type": "OraclePriceData",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self, oracle_price_data: OraclePriceData, slot: int) -> int"
+          },
+          {
+            "name": "is_base_filled",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self) -> bool"
+          },
+          {
+            "name": "is_vamm_node",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self) -> bool"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.dlob.dlob_subscriber",
+    "path": "dlob/dlob_subscriber.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "DLOBSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "url",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "config",
+                "kind": "positional_or_keyword",
+                "type": "Optional[DLOBClientConfig]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, url: Optional[str] = None, config: Optional[DLOBClientConfig] = None)"
+          },
+          {
+            "name": "close_session",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "cls",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(cls)"
+          },
+          {
+            "name": "decode_l2_orderbook",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "data",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "L2OrderBook"
+            },
+            "signature": "(self, data: str) -> L2OrderBook"
+          },
+          {
+            "name": "decode_l3_orderbook",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "data",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "L3OrderBook"
+            },
+            "signature": "(self, data: str) -> L3OrderBook"
+          },
+          {
+            "name": "get_dlob",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get_l2_orderbook",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market",
+                "kind": "positional_or_keyword",
+                "type": "MarketId",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "L2OrderBook"
+            },
+            "signature": "(self, market: MarketId) -> L2OrderBook"
+          },
+          {
+            "name": "get_l2_orderbook_sync",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_name",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "Optional[MarketType]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "include_vamm",
+                "kind": "positional_or_keyword",
+                "type": "Optional[bool]",
+                "required": false,
+                "default": "False"
+              },
+              {
+                "name": "num_vamm_orders",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "fallback_l2_generators",
+                "kind": "positional_or_keyword",
+                "type": "Optional[L2OrderBookGenerator]",
+                "required": false,
+                "default": "[]"
+              },
+              {
+                "name": "depth",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "10"
+              }
+            ],
+            "returns": {
+              "type": "L2OrderBook"
+            },
+            "signature": "(self, market_name: Optional[str] = None, market_index: Optional[int] = None, market_type: Optional[MarketType] = None, include_vamm: Optional[bool] = False, num_vamm_orders: Optional[int] = None, fallback_l2_generators: Optional[L2OrderBookGenerator] = [], depth: Optional[int] = 10) -> L2OrderBook"
+          },
+          {
+            "name": "get_l3_orderbook",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market",
+                "kind": "positional_or_keyword",
+                "type": "MarketId",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "L3OrderBook"
+            },
+            "signature": "(self, market: MarketId) -> L3OrderBook"
+          },
+          {
+            "name": "get_l3_orderbook_sync",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_name",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "Optional[MarketType]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "L3OrderBook"
+            },
+            "signature": "(self, market_name: Optional[str] = None, market_index: Optional[int] = None, market_type: Optional[MarketType] = None) -> L3OrderBook"
+          },
+          {
+            "name": "get_session",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "cls",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(cls)"
+          },
+          {
+            "name": "on_dlob_update",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": "This function CANNOT be used unless a `DLOBClientConfig` was provided in the `DLOBClient`'s constructor.\nIf it is used without a `DLOBClientConfig`, it will return nothing.",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "subscribe_l2_book",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market",
+                "kind": "positional_or_keyword",
+                "type": "MarketId",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "interval_s",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "1"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market: MarketId, interval_s: int = 1)"
+          },
+          {
+            "name": "subscribe_l3_book",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market",
+                "kind": "positional_or_keyword",
+                "type": "MarketId",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "interval_s",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "1"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market: MarketId, interval_s: int = 1)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "update_dlob",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      },
+      {
+        "name": "MarketId",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.dlob.node_list",
+    "path": "dlob/node_list.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "T"
+      }
+    ],
+    "functions": [
+      {
+        "name": "get_order_signature",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order_id",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "user_account",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "str"
+        },
+        "signature": "(order_id: int, user_account: Pubkey) -> str"
+      },
+      {
+        "name": "get_vamm_node_generator",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "price",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Generator[DLOBNode, None, None]"
+        },
+        "signature": "(price) -> Generator[DLOBNode, None, None]"
+      }
+    ],
+    "classes": [
+      {
+        "name": "NodeList",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "node_type",
+                "kind": "positional_or_keyword",
+                "type": "NodeType",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sort_direction",
+                "kind": "positional_or_keyword",
+                "type": "SortDirection",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, node_type: NodeType, sort_direction: SortDirection)"
+          },
+          {
+            "name": "clear",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_signature",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order_signature)"
+          },
+          {
+            "name": "get_generator",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Generator[DLOBNode, None, None]"
+            },
+            "signature": "(self) -> Generator[DLOBNode, None, None]"
+          },
+          {
+            "name": "has",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order: Order, user_account: Pubkey)"
+          },
+          {
+            "name": "insert",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order: Order, market_type, user_account: Pubkey)"
+          },
+          {
+            "name": "prepend_node",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "current_node",
+                "kind": "positional_or_keyword",
+                "type": "T",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "new_node",
+                "kind": "positional_or_keyword",
+                "type": "T",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self, current_node: T, new_node: T) -> bool"
+          },
+          {
+            "name": "print_list",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "print_top",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "remove",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order: Order, user_account: Pubkey)"
+          },
+          {
+            "name": "update",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order: Order, user_account: Pubkey)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.dlob.orderbook_levels",
+    "path": "dlob/orderbook_levels.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "DEFAULT_TOP_OF_BOOK_QUOTE_AMOUNTS"
+      }
+    ],
+    "functions": [
+      {
+        "name": "create_l2_levels",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "generator",
+            "kind": "positional_or_keyword",
+            "type": "Generator[L2Level, None, None]",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "depth",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "List[L2Level]"
+        },
+        "signature": "(generator: Generator[L2Level, None, None], depth: int) -> List[L2Level]"
+      },
+      {
+        "name": "get_l2_generator_from_dlob_nodes",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "dlob_nodes",
+            "kind": "positional_or_keyword",
+            "type": "Generator[DLOBNode, None, None]",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "slot",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Generator[L2Level, None, None]"
+        },
+        "signature": "(dlob_nodes: Generator[DLOBNode, None, None], oracle_price_data: OraclePriceData, slot: int) -> Generator[L2Level, None, None]"
+      },
+      {
+        "name": "get_vamm_l2_generator",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market_account",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "num_orders",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "now",
+            "kind": "positional_or_keyword",
+            "type": "Optional[int]",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "top_of_book_quote_amounts",
+            "kind": "positional_or_keyword",
+            "type": "Optional[List[int]]",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(market_account: PerpMarketAccount, oracle_price_data: OraclePriceData, num_orders: int, now: Optional[int] = None, top_of_book_quote_amounts: Optional[List[int]] = None)"
+      },
+      {
+        "name": "group_l2",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "l2",
+            "kind": "positional_or_keyword",
+            "type": "L2OrderBook",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "grouping",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "depth",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "L2OrderBook"
+        },
+        "signature": "(l2: L2OrderBook, grouping: int, depth: int) -> L2OrderBook"
+      },
+      {
+        "name": "group_l2_levels",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "levels",
+            "kind": "positional_or_keyword",
+            "type": "List[L2Level]",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "grouping",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "direction",
+            "kind": "positional_or_keyword",
+            "type": "PositionDirection",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "depth",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "List[L2Level]"
+        },
+        "signature": "(levels: List[L2Level], grouping: int, direction: PositionDirection, depth: int) -> List[L2Level]"
+      },
+      {
+        "name": "merge_l2_level_generators",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "l2_level_generators",
+            "kind": "positional_or_keyword",
+            "type": "List[Generator[L2Level, None, None]]",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "compare",
+            "kind": "positional_or_keyword",
+            "type": "callable",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Generator[L2Level, None, None]"
+        },
+        "signature": "(l2_level_generators: List[Generator[L2Level, None, None]], compare: callable) -> Generator[L2Level, None, None]"
+      }
+    ],
+    "classes": [
+      {
+        "name": "L2Level",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "price",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "size",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sources",
+                "kind": "positional_or_keyword",
+                "type": "Dict[str, int]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, price: int, size: int, sources: Dict[str, int])"
+          }
+        ]
+      },
+      {
+        "name": "L2OrderBook",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "asks",
+                "kind": "positional_or_keyword",
+                "type": "List[L2Level]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "bids",
+                "kind": "positional_or_keyword",
+                "type": "List[L2Level]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, asks: List[L2Level], bids: List[L2Level], slot: Optional[int] = None)"
+          }
+        ]
+      },
+      {
+        "name": "L2OrderBookGenerator",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "get_l2_asks",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Generator[L2Level, None, None]"
+            },
+            "signature": "(self) -> Generator[L2Level, None, None]"
+          },
+          {
+            "name": "get_l2_bids",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Generator[L2Level, None, None]"
+            },
+            "signature": "(self) -> Generator[L2Level, None, None]"
+          }
+        ]
+      },
+      {
+        "name": "L3Level",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "price",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "size",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "maker",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, price: int, size: int, maker: Pubkey, order_id: int)"
+          }
+        ]
+      },
+      {
+        "name": "L3OrderBook",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "asks",
+                "kind": "positional_or_keyword",
+                "type": "List[L3Level]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "bids",
+                "kind": "positional_or_keyword",
+                "type": "List[L3Level]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, asks: List[L3Level], bids: List[L3Level], slot: Optional[int] = None)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.drift_client",
+    "path": "drift_client.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "DEFAULT_TX_OPTIONS"
+      },
+      {
+        "name": "DEFAULT_USER_NAME"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "DriftClient",
+        "docstring": "This class is the main way to interact with Drift Protocol including\ndepositing, opening new positions, closing positions, placing orders, etc.",
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": "Initializes the drift client object\n\nArgs:\n    connection (AsyncClient): Solana RPC connection\n    wallet (Keypair | Wallet): Wallet for transaction signing\n    env (DriftEnv | None, optional): Drift environment. Defaults to \"mainnet\".\n    opts (TxOpts, optional): Transaction options. Defaults to DEFAULT_TX_OPTIONS.\n    authority (Pubkey | None, optional): Authority for transactions. If None, defaults to wallet's public key.\n    account_subscription (AccountSubscriptionConfig, optional): Config for account subscriptions. Defaults to AccountSubscriptionConfig.default().\n    perp_market_indexes (list[int] | None, optional): List of perp market indexes to subscribe to. Defaults to None.\n    spot_market_indexes (list[int] | None, optional): List of spot market indexes to subscribe to. Defaults to None.\n    oracle_infos (list[OracleInfo] | None, optional): List of oracle infos to subscribe to. Defaults to None.\n    tx_params (Optional[TxParams], optional): Transaction parameters. Defaults to None.\n    tx_version (Optional[TransactionVersion], optional): Transaction version. Defaults to None.\n    tx_sender (TxSender | None, optional): Custom transaction sender. Defaults to None.\n    active_sub_account_id (Optional[int], optional): Active sub-account ID. Defaults to None.\n    sub_account_ids (Optional[list[int]], optional): List of sub-account IDs. Defaults to None.\n    market_lookup_table (Optional[Pubkey], optional): Market lookup table pubkey (deprecated). Defaults to None.\n    market_lookup_tables (Optional[list[Pubkey]], optional): List of market lookup table pubkeys. Defaults to None.\n    jito_params (Optional[JitoParams], optional): Parameters for Jito MEV integration. Defaults to None.\n    tx_sender_blockhash_commitment (Commitment | None, optional): Blockhash commitment for tx sender. Defaults to None.\n    enforce_tx_sequencing (bool, optional): Whether to enforce transaction sequencing. Defaults to False.",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "connection",
+                "kind": "positional_or_keyword",
+                "type": "AsyncClient",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "wallet",
+                "kind": "positional_or_keyword",
+                "type": "Keypair | Wallet",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "env",
+                "kind": "positional_or_keyword",
+                "type": "DriftEnv | None",
+                "required": false,
+                "default": "'mainnet'"
+              },
+              {
+                "name": "opts",
+                "kind": "positional_or_keyword",
+                "type": "TxOpts",
+                "required": false,
+                "default": "DEFAULT_TX_OPTIONS"
+              },
+              {
+                "name": "authority",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey | None",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "account_subscription",
+                "kind": "positional_or_keyword",
+                "type": "AccountSubscriptionConfig",
+                "required": false,
+                "default": "AccountSubscriptionConfig.default()"
+              },
+              {
+                "name": "perp_market_indexes",
+                "kind": "positional_or_keyword",
+                "type": "list[int] | None",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "spot_market_indexes",
+                "kind": "positional_or_keyword",
+                "type": "list[int] | None",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "oracle_infos",
+                "kind": "positional_or_keyword",
+                "type": "list[OracleInfo] | None",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "tx_params",
+                "kind": "positional_or_keyword",
+                "type": "Optional[TxParams]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "tx_version",
+                "kind": "positional_or_keyword",
+                "type": "Optional[TransactionVersion]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "tx_sender",
+                "kind": "positional_or_keyword",
+                "type": "TxSender | None",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "active_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "sub_account_ids",
+                "kind": "positional_or_keyword",
+                "type": "Optional[list[int]]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "market_lookup_table",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Pubkey]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "market_lookup_tables",
+                "kind": "positional_or_keyword",
+                "type": "Optional[list[Pubkey]]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "jito_params",
+                "kind": "positional_or_keyword",
+                "type": "Optional[JitoParams]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "tx_sender_blockhash_commitment",
+                "kind": "positional_or_keyword",
+                "type": "Commitment | None",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "enforce_tx_sequencing",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, connection: AsyncClient, wallet: Keypair | Wallet, env: DriftEnv | None = 'mainnet', opts: TxOpts = DEFAULT_TX_OPTIONS, authority: Pubkey | None = None, account_subscription: AccountSubscriptionConfig = AccountSubscriptionConfig.default(), perp_market_indexes: list[int] | None = None, spot_market_indexes: list[int] | None = None, oracle_infos: list[OracleInfo] | None = None, tx_params: Optional[TxParams] = None, tx_version: Optional[TransactionVersion] = None, tx_sender: TxSender | None = None, active_sub_account_id: Optional[int] = None, sub_account_ids: Optional[list[int]] = None, market_lookup_table: Optional[Pubkey] = None, market_lookup_tables: Optional[list[Pubkey]] = None, jito_params: Optional[JitoParams] = None, tx_sender_blockhash_commitment: Commitment | None = None, enforce_tx_sequencing: bool = False)"
+          },
+          {
+            "name": "add_insurance_fund_stake",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_token_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_market_index: int, amount: int, user_token_account: Pubkey = None)"
+          },
+          {
+            "name": "add_liquidity",
+            "is_async": true,
+            "docstring": "mint LP tokens and add liquidity to the DAMM\n\nArgs:\n    amount (int): amount of lp tokens to mint\n    market_index (int): market you want to lp in\n    sub_account_id (int, optional): subaccount id. Defaults to 0.\n\nReturns:\n    Signature: tx sig",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "Signature"
+            },
+            "signature": "(self, amount: int, market_index: int, sub_account_id: int = None) -> Signature"
+          },
+          {
+            "name": "add_perp_market_to_remaining_account_maps",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "writable",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_account_map",
+                "kind": "positional_or_keyword",
+                "type": "dict[str, AccountMeta]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_account_map",
+                "kind": "positional_or_keyword",
+                "type": "dict[int, AccountMeta]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_market_account_map",
+                "kind": "positional_or_keyword",
+                "type": "dict[int, AccountMeta]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, market_index: int, writable: bool, oracle_account_map: dict[str, AccountMeta], spot_market_account_map: dict[int, AccountMeta], perp_market_account_map: dict[int, AccountMeta]) -> None"
+          },
+          {
+            "name": "add_phoenix_remaining_accounts",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "remaining_accounts",
+                "kind": "positional_or_keyword",
+                "type": "list[AccountMeta]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "fulfillment_config",
+                "kind": "positional_or_keyword",
+                "type": "PhoenixV1FulfillmentConfigAccount",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, market_index: int, remaining_accounts: list[AccountMeta], fulfillment_config: PhoenixV1FulfillmentConfigAccount) -> None"
+          },
+          {
+            "name": "add_serum_remaining_accounts",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "remaining_accounts",
+                "kind": "positional_or_keyword",
+                "type": "list[AccountMeta]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "fulfillment_config",
+                "kind": "positional_or_keyword",
+                "type": "SerumV3FulfillmentConfigAccount",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, market_index: int, remaining_accounts: list[AccountMeta], fulfillment_config: SerumV3FulfillmentConfigAccount) -> None"
+          },
+          {
+            "name": "add_spot_fulfillment_accounts",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "remaining_accounts",
+                "kind": "positional_or_keyword",
+                "type": "list[AccountMeta]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "fulfillment_config",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Union[SerumV3FulfillmentConfigAccount, PhoenixV1FulfillmentConfigAccount]]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, market_index: int, remaining_accounts: list[AccountMeta], fulfillment_config: Optional[Union[SerumV3FulfillmentConfigAccount, PhoenixV1FulfillmentConfigAccount]] = None) -> None"
+          },
+          {
+            "name": "add_spot_market_to_remaining_account_maps",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "writable",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_account_map",
+                "kind": "positional_or_keyword",
+                "type": "dict[str, AccountMeta]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_account_map",
+                "kind": "positional_or_keyword",
+                "type": "dict[int, AccountMeta]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, market_index: int, writable: bool, oracle_account_map: dict[str, AccountMeta], spot_market_account_map: dict[int, AccountMeta]) -> None"
+          },
+          {
+            "name": "add_user",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, sub_account_id: int)"
+          },
+          {
+            "name": "add_user_stats",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "authority",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, authority: Pubkey)"
+          },
+          {
+            "name": "cancel_and_place_orders",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "cancel_params",
+                "kind": "positional_or_keyword",
+                "type": "Tuple[Optional[MarketType], Optional[int], Optional[PositionDirection]]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "place_order_params",
+                "kind": "positional_or_keyword",
+                "type": "List[OrderParams]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, cancel_params: Tuple[Optional[MarketType], Optional[int], Optional[PositionDirection]], place_order_params: List[OrderParams], sub_account_id: Optional[int] = None)"
+          },
+          {
+            "name": "cancel_order",
+            "is_async": true,
+            "docstring": "cancel specific order (if order_id=None will be most recent order)\n\nArgs:\n    order_id (Optional[int], optional): Defaults to None.\n    sub_account_id (int, optional): subaccount id which contains order. Defaults to 0.\n\nReturns:\n    str: tx sig",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_id",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "Signature"
+            },
+            "signature": "(self, order_id: Optional[int] = None, sub_account_id: int = None) -> Signature"
+          },
+          {
+            "name": "cancel_order_by_user_id",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_order_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_order_id: int, sub_account_id: int = None)"
+          },
+          {
+            "name": "cancel_orders",
+            "is_async": true,
+            "docstring": "cancel all existing orders on the book\n\nArgs:\n    market_type (MarketType, optional): only cancel orders for single market, used with market_index\n    market_index (int, optional): only cancel orders for single market, used with market_type\n    direction: (PositionDirection, optional): only cancel bids or asks\n    sub_account_id (int, optional): subaccount id. Defaults to 0.\n\nReturns:\n    Signature: tx sig",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "direction",
+                "kind": "positional_or_keyword",
+                "type": "PositionDirection",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "Signature"
+            },
+            "signature": "(self, market_type: MarketType = None, market_index: int = None, direction: PositionDirection = None, sub_account_id: int = None) -> Signature"
+          },
+          {
+            "name": "cancel_request_remove_insurance_fund_stake",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_market_index: int)"
+          },
+          {
+            "name": "close_position",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "limit_price",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int, limit_price: int = 0, sub_account_id: int = None)"
+          },
+          {
+            "name": "convert_to_perp_precision",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "Union[int, float]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self, amount: Union[int, float]) -> int"
+          },
+          {
+            "name": "convert_to_price_precision",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "Union[int, float]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self, amount: Union[int, float]) -> int"
+          },
+          {
+            "name": "convert_to_spot_precision",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "Union[int, float]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self, amount: Union[int, float], market_index) -> int"
+          },
+          {
+            "name": "create_associated_token_account_idempotent_instruction",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "payer",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "owner",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "mint",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, account: Pubkey, payer: Pubkey, owner: Pubkey, mint: Pubkey)"
+          },
+          {
+            "name": "decode_signed_msg_order_params_message",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "signed_msg_order_params_buf",
+                "kind": "positional_or_keyword",
+                "type": "bytes",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "is_delegate",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": "Union[SignedMsgOrderParamsMessage, SignedMsgOrderParamsDelegateMessage]"
+            },
+            "signature": "(self, signed_msg_order_params_buf: bytes, is_delegate: bool = False) -> Union[SignedMsgOrderParamsMessage, SignedMsgOrderParamsDelegateMessage]"
+          },
+          {
+            "name": "deposit",
+            "is_async": true,
+            "docstring": "deposits collateral into protocol\n\nArgs:\n    amount (int): amount to deposit\n    spot_market_index (int):\n    user_token_account (Pubkey):\n    sub_account_id (int, optional): subaccount to deposit into. Defaults to 0.\n    reduce_only (bool, optional): paying back borrow vs depositing new assets. Defaults to False.\n    user_initialized (bool, optional): if need to initialize user account too set this to False. Defaults to True.\n\nReturns:\n    TxSigAndSlot: tx sig and slot",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_token_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "reduce_only",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "False"
+              },
+              {
+                "name": "user_initialized",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "True"
+              }
+            ],
+            "returns": {
+              "type": "TxSigAndSlot"
+            },
+            "signature": "(self, amount: int, spot_market_index: int, user_token_account: Pubkey, sub_account_id: Optional[int] = None, reduce_only = False, user_initialized = True) -> TxSigAndSlot"
+          },
+          {
+            "name": "encode_signed_msg_order_params_message",
+            "is_async": false,
+            "docstring": "Borsh encode signedMsg order params message\n\nArgs:\n    order_params_message: The order params message to encode\n    delegate_signer: Whether to use delegate message format\n\nReturns:\n    The encoded buffer",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_params_message",
+                "kind": "positional_or_keyword",
+                "type": "Union[dict, SignedMsgOrderParamsMessage, SignedMsgOrderParamsDelegateMessage]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "delegate_signer",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": "bytes"
+            },
+            "signature": "(self, order_params_message: Union[dict, SignedMsgOrderParamsMessage, SignedMsgOrderParamsDelegateMessage], delegate_signer: bool = False) -> bytes"
+          },
+          {
+            "name": "fetch_market_lookup_table",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "AddressLookupTableAccount"
+            },
+            "signature": "(self) -> AddressLookupTableAccount"
+          },
+          {
+            "name": "fetch_market_lookup_table_accounts",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "fill_perp_order",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account_pubkey",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "UserAccount",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "maker_info",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Union[MakerInfo, list[MakerInfo]]]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "referrer_info",
+                "kind": "positional_or_keyword",
+                "type": "Optional[ReferrerInfo]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_account_pubkey: Pubkey, user_account: UserAccount, order: Order, maker_info: Optional[Union[MakerInfo, list[MakerInfo]]], referrer_info: Optional[ReferrerInfo])"
+          },
+          {
+            "name": "force_cancel_orders",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account_pubkey",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "UserAccount",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "filler_pubkey",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Pubkey]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "Signature"
+            },
+            "signature": "(self, user_account_pubkey: Pubkey, user_account: UserAccount, filler_pubkey: Optional[Pubkey] = None) -> Signature"
+          },
+          {
+            "name": "get_add_insurance_fund_stake_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_token_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_market_index: int, amount: int, user_token_account: Pubkey = None)"
+          },
+          {
+            "name": "get_add_liquidity_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, amount: int, market_index: int, sub_account_id: int = None)"
+          },
+          {
+            "name": "get_associated_token_account_public_key",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Pubkey"
+            },
+            "signature": "(self, market_index: int) -> Pubkey"
+          },
+          {
+            "name": "get_cancel_and_place_orders_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "cancel_params",
+                "kind": "positional_or_keyword",
+                "type": "Tuple[Optional[MarketType], Optional[int], Optional[PositionDirection]]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "place_order_params",
+                "kind": "positional_or_keyword",
+                "type": "List[OrderParams]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, cancel_params: Tuple[Optional[MarketType], Optional[int], Optional[PositionDirection]], place_order_params: List[OrderParams], sub_account_id: Optional[int] = None)"
+          },
+          {
+            "name": "get_cancel_order_by_user_id_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_order_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_order_id: int, sub_account_id: int = None)"
+          },
+          {
+            "name": "get_cancel_order_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_id",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order_id: Optional[int] = None, sub_account_id: int = None)"
+          },
+          {
+            "name": "get_cancel_orders_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_type",
+                "kind": "positional_or_keyword",
+                "type": "MarketType",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "direction",
+                "kind": "positional_or_keyword",
+                "type": "PositionDirection",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_type: MarketType = None, market_index: int = None, direction: PositionDirection = None, sub_account_id: int = None)"
+          },
+          {
+            "name": "get_cancel_request_remove_insurance_fund_stake_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_token_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_market_index: int, user_token_account: Pubkey = None)"
+          },
+          {
+            "name": "get_check_and_set_sequence_number_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sequence_number",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "subaccount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, sequence_number: Optional[int] = None, subaccount: int = 0)"
+          },
+          {
+            "name": "get_close_position_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "limit_price",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int, limit_price: int = 0, sub_account_id: int = None)"
+          },
+          {
+            "name": "get_deposit_collateral_ix",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_token_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "reduce_only",
+                "kind": "positional_or_keyword",
+                "type": "Optional[bool]",
+                "required": false,
+                "default": "False"
+              },
+              {
+                "name": "user_initialized",
+                "kind": "positional_or_keyword",
+                "type": "Optional[bool]",
+                "required": false,
+                "default": "True"
+              }
+            ],
+            "returns": {
+              "type": "List[Instruction]"
+            },
+            "signature": "(self, amount: int, spot_market_index: int, user_token_account: Pubkey, sub_account_id: Optional[int] = None, reduce_only: Optional[bool] = False, user_initialized: Optional[bool] = True) -> List[Instruction]"
+          },
+          {
+            "name": "get_fill_perp_order_ix",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account_pubkey",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "UserAccount",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "maker_info",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Union[MakerInfo, list[MakerInfo]]]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "referrer_info",
+                "kind": "positional_or_keyword",
+                "type": "Optional[ReferrerInfo]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Instruction"
+            },
+            "signature": "(self, user_account_pubkey: Pubkey, user_account: UserAccount, order: Order, maker_info: Optional[Union[MakerInfo, list[MakerInfo]]], referrer_info: Optional[ReferrerInfo]) -> Instruction"
+          },
+          {
+            "name": "get_force_cancel_orders_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account_pubkey",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "UserAccount",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "filler_pubkey",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Pubkey]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_account_pubkey: Pubkey, user_account: UserAccount, filler_pubkey: Optional[Pubkey] = None)"
+          },
+          {
+            "name": "get_initialize_insurance_fund_stake_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_market_index: int)"
+          },
+          {
+            "name": "get_initialize_user_instructions",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "name",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": false,
+                "default": "DEFAULT_USER_NAME"
+              },
+              {
+                "name": "referrer_info",
+                "kind": "positional_or_keyword",
+                "type": "ReferrerInfo",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "Instruction"
+            },
+            "signature": "(self, sub_account_id: int = 0, name: str = DEFAULT_USER_NAME, referrer_info: ReferrerInfo = None) -> Instruction"
+          },
+          {
+            "name": "get_initialize_user_stats",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get_jupiter_swap_ix_v6",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "out_market_idx",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "in_market_idx",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "out_ata",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Pubkey]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "in_ata",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Pubkey]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "slippage_bps",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "50"
+              },
+              {
+                "name": "quote",
+                "kind": "positional_or_keyword",
+                "type": "Optional[dict]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "reduce_only",
+                "kind": "positional_or_keyword",
+                "type": "Optional[SwapReduceOnly]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "user_account_public_key",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Pubkey]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "swap_mode",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": false,
+                "default": "'ExactIn'"
+              },
+              {
+                "name": "fee_account",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Pubkey]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "platform_fee_bps",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "only_direct_routes",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "False"
+              },
+              {
+                "name": "max_accounts",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "50"
+              }
+            ],
+            "returns": {
+              "type": "Tuple[list[Instruction], list[AddressLookupTableAccount]]"
+            },
+            "signature": "(self, out_market_idx: int, in_market_idx: int, amount: int, out_ata: Optional[Pubkey] = None, in_ata: Optional[Pubkey] = None, slippage_bps: int = 50, quote: Optional[dict] = None, reduce_only: Optional[SwapReduceOnly] = None, user_account_public_key: Optional[Pubkey] = None, swap_mode: str = 'ExactIn', fee_account: Optional[Pubkey] = None, platform_fee_bps: Optional[int] = None, only_direct_routes: bool = False, max_accounts: int = 50) -> Tuple[list[Instruction], list[AddressLookupTableAccount]]"
+          },
+          {
+            "name": "get_liquidate_perp_ix",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_authority",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "max_base_asset_amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "limit_price",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "user_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "liq_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_authority: Pubkey, market_index: int, max_base_asset_amount: int, limit_price: Optional[int] = None, user_sub_account_id: int = 0, liq_sub_account_id: int = None)"
+          },
+          {
+            "name": "get_liquidate_perp_pnl_for_deposit_ix",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_authority",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "max_pnl_transfer",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "limit_price",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "user_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "liq_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_authority: Pubkey, perp_market_index: int, spot_market_index: int, max_pnl_transfer: int, limit_price: int = None, user_sub_account_id: int = 0, liq_sub_account_id: int = None)"
+          },
+          {
+            "name": "get_liquidate_spot_ix",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_authority",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "asset_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "liability_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "max_liability_transfer",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "limit_price",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "user_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "liq_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_authority: Pubkey, asset_market_index: int, liability_market_index: int, max_liability_transfer: int, limit_price: int = None, user_sub_account_id: int = 0, liq_sub_account_id: int = None)"
+          },
+          {
+            "name": "get_market_index_and_type",
+            "is_async": false,
+            "docstring": "Returns the market index and type for a given market name \n\nReturns `None` if the market name couldn't be matched \n\ne.g. \"SOL-PERP\" -> `(0, MarketType.Perp())`",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "name",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Union[Tuple[int, MarketType], None]"
+            },
+            "signature": "(self, name: str) -> Union[Tuple[int, MarketType], None]"
+          },
+          {
+            "name": "get_modify_order_by_user_id_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_order_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "modify_order_params",
+                "kind": "positional_or_keyword",
+                "type": "ModifyOrderParams",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_order_id: int, modify_order_params: ModifyOrderParams, sub_account_id: int = None)"
+          },
+          {
+            "name": "get_modify_order_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "modify_order_params",
+                "kind": "positional_or_keyword",
+                "type": "ModifyOrderParams",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order_id: int, modify_order_params: ModifyOrderParams, sub_account_id: int = None)"
+          },
+          {
+            "name": "get_open_position_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "direction",
+                "kind": "positional_or_keyword",
+                "type": "PositionDirection",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "limit_price",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "ioc",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, direction: PositionDirection, amount: int, market_index: int, sub_account_id: int = None, limit_price: int = 0, ioc: bool = False)"
+          },
+          {
+            "name": "get_oracle_price_data",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "oracle_id",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[OraclePriceData]"
+            },
+            "signature": "(self, oracle_id: str) -> Optional[OraclePriceData]"
+          },
+          {
+            "name": "get_oracle_price_data_for_perp_market",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[OraclePriceData]"
+            },
+            "signature": "(self, market_index: int) -> Optional[OraclePriceData]"
+          },
+          {
+            "name": "get_oracle_price_data_for_spot_market",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[OraclePriceData]"
+            },
+            "signature": "(self, market_index: int) -> Optional[OraclePriceData]"
+          },
+          {
+            "name": "get_perp_market_account",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[PerpMarketAccount]"
+            },
+            "signature": "(self, market_index: int) -> Optional[PerpMarketAccount]"
+          },
+          {
+            "name": "get_perp_market_accounts",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "list[PerpMarketAccount]"
+            },
+            "signature": "(self) -> list[PerpMarketAccount]"
+          },
+          {
+            "name": "get_perp_position",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "Optional[PerpPosition]"
+            },
+            "signature": "(self, market_index: int, sub_account_id: int = None) -> Optional[PerpPosition]"
+          },
+          {
+            "name": "get_place_and_make_signed_msg_perp_order_ixs",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "signed_msg_order_params",
+                "kind": "positional_or_keyword",
+                "type": "SignedMsgOrderParams",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "signed_msg_order_uuid",
+                "kind": "positional_or_keyword",
+                "type": "bytes",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "taker_info",
+                "kind": "positional_or_keyword",
+                "type": "dict",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_params",
+                "kind": "positional_or_keyword",
+                "type": "OrderParams",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "referrer_info",
+                "kind": "positional_or_keyword",
+                "type": "Optional[ReferrerInfo]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "preceding_ixs",
+                "kind": "positional_or_keyword",
+                "type": "list[Instruction]",
+                "required": false,
+                "default": "[]"
+              },
+              {
+                "name": "override_ix_count",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "include_high_leverage_mode_config",
+                "kind": "positional_or_keyword",
+                "type": "Optional[bool]",
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": "list[Instruction]"
+            },
+            "signature": "(self, signed_msg_order_params: SignedMsgOrderParams, signed_msg_order_uuid: bytes, taker_info: dict, order_params: OrderParams, referrer_info: Optional[ReferrerInfo] = None, sub_account_id: Optional[int] = None, preceding_ixs: list[Instruction] = [], override_ix_count: Optional[int] = None, include_high_leverage_mode_config: Optional[bool] = False) -> list[Instruction]"
+          },
+          {
+            "name": "get_place_and_take_perp_order_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_params",
+                "kind": "positional_or_keyword",
+                "type": "OrderParams",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "maker_info",
+                "kind": "positional_or_keyword",
+                "type": "Union[MakerInfo, List[MakerInfo]]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "referrer_info",
+                "kind": "positional_or_keyword",
+                "type": "ReferrerInfo",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order_params: OrderParams, maker_info: Union[MakerInfo, List[MakerInfo]] = None, referrer_info: ReferrerInfo = None, sub_account_id: int = None)"
+          },
+          {
+            "name": "get_place_and_take_spot_order_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_params",
+                "kind": "positional_or_keyword",
+                "type": "OrderParams",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "fulfillment_config",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Union[SerumV3FulfillmentConfigAccount, PhoenixV1FulfillmentConfigAccount]]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "maker_info",
+                "kind": "positional_or_keyword",
+                "type": "Union[MakerInfo, List[MakerInfo]]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "referrer_info",
+                "kind": "positional_or_keyword",
+                "type": "ReferrerInfo",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order_params: OrderParams, fulfillment_config: Optional[Union[SerumV3FulfillmentConfigAccount, PhoenixV1FulfillmentConfigAccount]] = None, maker_info: Union[MakerInfo, List[MakerInfo]] = None, referrer_info: ReferrerInfo = None, sub_account_id: int = None)"
+          },
+          {
+            "name": "get_place_orders_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_params",
+                "kind": "positional_or_keyword",
+                "type": "List[OrderParams]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order_params: List[OrderParams], sub_account_id: int = None)"
+          },
+          {
+            "name": "get_place_perp_order_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_params",
+                "kind": "positional_or_keyword",
+                "type": "OrderParams",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order_params: OrderParams, sub_account_id: int = None)"
+          },
+          {
+            "name": "get_place_signed_msg_taker_perp_order_ixs",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "signed_msg_order_params",
+                "kind": "positional_or_keyword",
+                "type": "Union[dict, SignedMsgOrderParams]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "taker_info",
+                "kind": "positional_or_keyword",
+                "type": "dict",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "authority",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Pubkey]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "preceding_ixs",
+                "kind": "positional_or_keyword",
+                "type": "list[Instruction]",
+                "required": false,
+                "default": "[]"
+              },
+              {
+                "name": "override_ix_count",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "include_high_leverage_mode_config",
+                "kind": "positional_or_keyword",
+                "type": "Optional[bool]",
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, signed_msg_order_params: Union[dict, SignedMsgOrderParams], market_index: int, taker_info: dict, authority: Optional[Pubkey] = None, preceding_ixs: list[Instruction] = [], override_ix_count: Optional[int] = None, include_high_leverage_mode_config: Optional[bool] = False)"
+          },
+          {
+            "name": "get_place_spot_order_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_params",
+                "kind": "positional_or_keyword",
+                "type": "OrderParams",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order_params: OrderParams, sub_account_id: int = None)"
+          },
+          {
+            "name": "get_quote_spot_market_account",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[SpotMarketAccount]"
+            },
+            "signature": "(self) -> Optional[SpotMarketAccount]"
+          },
+          {
+            "name": "get_remaining_accounts",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_accounts",
+                "kind": "positional_or_keyword",
+                "type": "list[UserAccount]",
+                "required": false,
+                "default": "()"
+              },
+              {
+                "name": "writable_perp_market_indexes",
+                "kind": "positional_or_keyword",
+                "type": "list[int]",
+                "required": false,
+                "default": "()"
+              },
+              {
+                "name": "writable_spot_market_indexes",
+                "kind": "positional_or_keyword",
+                "type": "list[int]",
+                "required": false,
+                "default": "()"
+              },
+              {
+                "name": "readable_spot_market_indexes",
+                "kind": "positional_or_keyword",
+                "type": "list[int]",
+                "required": false,
+                "default": "()"
+              },
+              {
+                "name": "readable_perp_market_indexes",
+                "kind": "positional_or_keyword",
+                "type": "list[int]",
+                "required": false,
+                "default": "()"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_accounts: list[UserAccount] = (), writable_perp_market_indexes: list[int] = (), writable_spot_market_indexes: list[int] = (), readable_spot_market_indexes: list[int] = (), readable_perp_market_indexes: list[int] = ())"
+          },
+          {
+            "name": "get_remaining_accounts_for_users",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_accounts",
+                "kind": "positional_or_keyword",
+                "type": "list[UserAccount]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "(dict[str, AccountMeta], dict[int, AccountMeta], dict[int, AccountMeta])"
+            },
+            "signature": "(self, user_accounts: list[UserAccount]) -> (dict[str, AccountMeta], dict[int, AccountMeta], dict[int, AccountMeta])"
+          },
+          {
+            "name": "get_remove_insurance_fund_stake_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_token_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_market_index: int, user_token_account: Pubkey = None)"
+          },
+          {
+            "name": "get_remove_liquidity_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, amount: int, market_index: int, sub_account_id: int = None)"
+          },
+          {
+            "name": "get_request_remove_insurance_fund_stake_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_market_index: int, amount: int)"
+          },
+          {
+            "name": "get_reset_sequence_number_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sequence_number",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "subaccount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              }
+            ],
+            "returns": {
+              "type": "Instruction"
+            },
+            "signature": "(self, sequence_number: int, subaccount: int = 0) -> Instruction"
+          },
+          {
+            "name": "get_resolve_perp_bankruptcy_ix",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_authority",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "liq_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_authority: Pubkey, market_index: int, user_sub_account_id: int = 0, liq_sub_account_id: int = None)"
+          },
+          {
+            "name": "get_resolve_spot_bankruptcy_ix",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_authority",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "liq_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_authority: Pubkey, spot_market_index: int, user_sub_account_id: int = 0, liq_sub_account_id: int = None)"
+          },
+          {
+            "name": "get_revert_fill_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get_sequence_init_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "subaccount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              }
+            ],
+            "returns": {
+              "type": "Instruction"
+            },
+            "signature": "(self, subaccount: int = 0) -> Instruction"
+          },
+          {
+            "name": "get_settle_expired_market_ix",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int)"
+          },
+          {
+            "name": "get_settle_lp_ix",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "settlee_user_account_public_key",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, settlee_user_account_public_key: Pubkey, market_index: int)"
+          },
+          {
+            "name": "get_settle_pnl_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "settlee_user_public_key",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "settlee_user_account",
+                "kind": "positional_or_keyword",
+                "type": "UserAccount",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, settlee_user_public_key: Pubkey, settlee_user_account: UserAccount, market_index: int)"
+          },
+          {
+            "name": "get_settle_pnl_ixs",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "users",
+                "kind": "positional_or_keyword",
+                "type": "dict[Pubkey, UserAccount]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_indexes",
+                "kind": "positional_or_keyword",
+                "type": "list[int]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "list[Instruction]"
+            },
+            "signature": "(self, users: dict[Pubkey, UserAccount], market_indexes: list[int]) -> list[Instruction]"
+          },
+          {
+            "name": "get_signer_public_key",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Pubkey"
+            },
+            "signature": "(self) -> Pubkey"
+          },
+          {
+            "name": "get_spot_market_account",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[SpotMarketAccount]"
+            },
+            "signature": "(self, market_index: int) -> Optional[SpotMarketAccount]"
+          },
+          {
+            "name": "get_spot_market_accounts",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "list[SpotMarketAccount]"
+            },
+            "signature": "(self) -> list[SpotMarketAccount]"
+          },
+          {
+            "name": "get_spot_position",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "Optional[SpotPosition]"
+            },
+            "signature": "(self, market_index: int, sub_account_id: int = None) -> Optional[SpotPosition]"
+          },
+          {
+            "name": "get_state_account",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[StateAccount]"
+            },
+            "signature": "(self) -> Optional[StateAccount]"
+          },
+          {
+            "name": "get_state_public_key",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get_sub_account_id_for_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, sub_account_id: Optional[int] = None)"
+          },
+          {
+            "name": "get_swap_flash_loan_ix",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "out_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "in_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount_in",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "in_ata",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "out_ata",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "limit_price",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "reduce_only",
+                "kind": "positional_or_keyword",
+                "type": "Optional[SwapReduceOnly]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "user_account_public_key",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Pubkey]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, out_market_index: int, in_market_index: int, amount_in: int, in_ata: Pubkey, out_ata: Pubkey, limit_price: Optional[int] = 0, reduce_only: Optional[SwapReduceOnly] = None, user_account_public_key: Optional[Pubkey] = None)"
+          },
+          {
+            "name": "get_transfer_deposit_ix",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "from_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "to_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, amount: int, market_index: int, from_sub_account_id: int, to_sub_account_id: int)"
+          },
+          {
+            "name": "get_trigger_order_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account_pubkey",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account",
+                "kind": "positional_or_keyword",
+                "type": "UserAccount",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order",
+                "kind": "positional_or_keyword",
+                "type": "Order",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "filler_pubkey",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Pubkey]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_account_pubkey: Pubkey, user_account: UserAccount, order: Order, filler_pubkey: Optional[Pubkey] = None)"
+          },
+          {
+            "name": "get_update_amm_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_indexs",
+                "kind": "positional_or_keyword",
+                "type": "list[int]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_indexs: list[int])"
+          },
+          {
+            "name": "get_update_prelaunch_oracle_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int)"
+          },
+          {
+            "name": "get_update_user_margin_trading_enabled_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "margin_trading_enabled",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "Instruction"
+            },
+            "signature": "(self, margin_trading_enabled: bool, sub_account_id: Optional[int] = None) -> Instruction"
+          },
+          {
+            "name": "get_update_user_protected_maker_orders_ix",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "protected_orders",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, sub_account_id: int, protected_orders: bool)"
+          },
+          {
+            "name": "get_user",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int | None",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "DriftUser"
+            },
+            "signature": "(self, sub_account_id: int | None = None) -> DriftUser"
+          },
+          {
+            "name": "get_user_account",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "UserAccount"
+            },
+            "signature": "(self, sub_account_id = None) -> UserAccount"
+          },
+          {
+            "name": "get_user_account_public_key",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "Pubkey"
+            },
+            "signature": "(self, sub_account_id = None) -> Pubkey"
+          },
+          {
+            "name": "get_user_stats",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "authority",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "DriftUserStats"
+            },
+            "signature": "(self, authority = None) -> DriftUserStats"
+          },
+          {
+            "name": "get_user_stats_public_key",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get_withdraw_collateral_ix",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_token_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "reduce_only",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "False"
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "List[Instruction]"
+            },
+            "signature": "(self, amount: int, market_index: int, user_token_account: Pubkey, reduce_only: bool = False, sub_account_id: Optional[int] = None) -> List[Instruction]"
+          },
+          {
+            "name": "get_wrapped_sol_account_creation_ixs",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "include_rent",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "True"
+              }
+            ],
+            "returns": {
+              "type": "(List[Instruction], Pubkey)"
+            },
+            "signature": "(self, amount: int, include_rent: bool = True) -> (List[Instruction], Pubkey)"
+          },
+          {
+            "name": "init_sequence",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "subaccount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              }
+            ],
+            "returns": {
+              "type": "Signature"
+            },
+            "signature": "(self, subaccount: int = 0) -> Signature"
+          },
+          {
+            "name": "initialize_insurance_fund_stake",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_market_index: int)"
+          },
+          {
+            "name": "initialize_user",
+            "is_async": true,
+            "docstring": "intializes a drift user\n\nArgs:\n    sub_account_id (int, optional): subaccount id to initialize. Defaults to 0.\n\nReturns:\n    str: tx signature",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "name",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "referrer_info",
+                "kind": "positional_or_keyword",
+                "type": "ReferrerInfo",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "Signature"
+            },
+            "signature": "(self, sub_account_id: int = 0, name: str = None, referrer_info: ReferrerInfo = None) -> Signature"
+          },
+          {
+            "name": "liquidate_perp",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_authority",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "max_base_asset_amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "limit_price",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "user_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "liq_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_authority: Pubkey, market_index: int, max_base_asset_amount: int, limit_price: Optional[int] = None, user_sub_account_id: int = 0, liq_sub_account_id: int = None)"
+          },
+          {
+            "name": "liquidate_perp_pnl_for_deposit",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_authority",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "max_pnl_transfer",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "liq_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_authority: Pubkey, perp_market_index: int, spot_market_index: int, max_pnl_transfer: int, user_sub_account_id: int = 0, liq_sub_account_id: int = None)"
+          },
+          {
+            "name": "liquidate_spot",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_authority",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "asset_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "liability_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "max_liability_transfer",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "liq_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_authority: Pubkey, asset_market_index: int, liability_market_index: int, max_liability_transfer: int, user_sub_account_id: int = 0, liq_sub_account_id: int = None)"
+          },
+          {
+            "name": "load_sequence_info",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "modify_order",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "modify_order_params",
+                "kind": "positional_or_keyword",
+                "type": "ModifyOrderParams",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "Signature"
+            },
+            "signature": "(self, order_id: int, modify_order_params: ModifyOrderParams, sub_account_id: Optional[int] = None) -> Signature"
+          },
+          {
+            "name": "modify_order_by_user_id",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_order_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "modify_order_params",
+                "kind": "positional_or_keyword",
+                "type": "ModifyOrderParams",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "Signature"
+            },
+            "signature": "(self, user_order_id: int, modify_order_params: ModifyOrderParams, sub_account_id: int = None) -> Signature"
+          },
+          {
+            "name": "open_position",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "direction",
+                "kind": "positional_or_keyword",
+                "type": "PositionDirection",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "limit_price",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "ioc",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, direction: PositionDirection, amount: int, market_index: int, sub_account_id: int = None, limit_price: int = 0, ioc: bool = False)"
+          },
+          {
+            "name": "place_and_make_signed_msg_perp_order",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "signed_msg_order_params",
+                "kind": "positional_or_keyword",
+                "type": "SignedMsgOrderParams",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "signed_msg_order_uuid",
+                "kind": "positional_or_keyword",
+                "type": "bytes",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "taker_info",
+                "kind": "positional_or_keyword",
+                "type": "dict",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_params",
+                "kind": "positional_or_keyword",
+                "type": "OrderParams",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, signed_msg_order_params: SignedMsgOrderParams, signed_msg_order_uuid: bytes, taker_info: dict, order_params: OrderParams)"
+          },
+          {
+            "name": "place_and_take_perp_order",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_params",
+                "kind": "positional_or_keyword",
+                "type": "OrderParams",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "maker_info",
+                "kind": "positional_or_keyword",
+                "type": "Union[MakerInfo, List[MakerInfo]]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "referrer_info",
+                "kind": "positional_or_keyword",
+                "type": "ReferrerInfo",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order_params: OrderParams, maker_info: Union[MakerInfo, List[MakerInfo]] = None, referrer_info: ReferrerInfo = None, sub_account_id: int = None)"
+          },
+          {
+            "name": "place_and_take_spot_order",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_params",
+                "kind": "positional_or_keyword",
+                "type": "OrderParams",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "fulfillment_config",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Union[SerumV3FulfillmentConfigAccount, PhoenixV1FulfillmentConfigAccount]]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "maker_info",
+                "kind": "positional_or_keyword",
+                "type": "Union[MakerInfo, List[MakerInfo]]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "referrer_info",
+                "kind": "positional_or_keyword",
+                "type": "ReferrerInfo",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order_params: OrderParams, fulfillment_config: Optional[Union[SerumV3FulfillmentConfigAccount, PhoenixV1FulfillmentConfigAccount]] = None, maker_info: Union[MakerInfo, List[MakerInfo]] = None, referrer_info: ReferrerInfo = None, sub_account_id: int = None)"
+          },
+          {
+            "name": "place_orders",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_params",
+                "kind": "positional_or_keyword",
+                "type": "List[OrderParams]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order_params: List[OrderParams], sub_account_id: int = None)"
+          },
+          {
+            "name": "place_perp_order",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_params",
+                "kind": "positional_or_keyword",
+                "type": "OrderParams",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order_params: OrderParams, sub_account_id: int = None)"
+          },
+          {
+            "name": "place_signed_msg_taker_order",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "signed_msg_order_params",
+                "kind": "positional_or_keyword",
+                "type": "SignedMsgOrderParams",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "taker_info",
+                "kind": "positional_or_keyword",
+                "type": "dict",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "preceding_ixs",
+                "kind": "positional_or_keyword",
+                "type": "list[Instruction]",
+                "required": false,
+                "default": "[]"
+              },
+              {
+                "name": "override_ix_count",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "include_high_leverage_mode_config",
+                "kind": "positional_or_keyword",
+                "type": "Optional[bool]",
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": "TxSigAndSlot"
+            },
+            "signature": "(self, signed_msg_order_params: SignedMsgOrderParams, market_index: int, taker_info: dict, preceding_ixs: list[Instruction] = [], override_ix_count: Optional[int] = None, include_high_leverage_mode_config: Optional[bool] = False) -> TxSigAndSlot"
+          },
+          {
+            "name": "place_spot_order",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_params",
+                "kind": "positional_or_keyword",
+                "type": "OrderParams",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order_params: OrderParams, sub_account_id: int = None)"
+          },
+          {
+            "name": "random_string",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "length",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "str"
+            },
+            "signature": "(self, length: int) -> str"
+          },
+          {
+            "name": "remove_insurance_fund_stake",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_token_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_market_index: int, user_token_account: Pubkey = None)"
+          },
+          {
+            "name": "remove_liquidity",
+            "is_async": true,
+            "docstring": "burns LP tokens and removes liquidity to the DAMM\n\nArgs:\n    amount (int): amount of lp tokens to burn\n    market_index (int):\n    sub_account_id (int, optional): subaccount id. Defaults to 0.\n\nReturns:\n    Signature: tx sig",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "Signature"
+            },
+            "signature": "(self, amount: int, market_index: int, sub_account_id: int = None) -> Signature"
+          },
+          {
+            "name": "request_remove_insurance_fund_stake",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_market_index: int, amount: int)"
+          },
+          {
+            "name": "reset_sequence_number",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sequence_number",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "subaccount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              }
+            ],
+            "returns": {
+              "type": "Signature"
+            },
+            "signature": "(self, sequence_number: int = 0, subaccount: int = 0) -> Signature"
+          },
+          {
+            "name": "resolve_perp_bankruptcy",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_authority",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "liq_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_authority: Pubkey, market_index: int, user_sub_account_id: int = 0, liq_sub_account_id: int = None)"
+          },
+          {
+            "name": "resolve_spot_bankruptcy",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_authority",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "0"
+              },
+              {
+                "name": "liq_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_authority: Pubkey, spot_market_index: int, user_sub_account_id: int = 0, liq_sub_account_id: int = None)"
+          },
+          {
+            "name": "resurrect",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_markets",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_markets",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_oracles",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_oracles",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_markets, perp_markets, spot_oracles, perp_oracles)"
+          },
+          {
+            "name": "send_ixs",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "ixs",
+                "kind": "positional_or_keyword",
+                "type": "Union[Instruction, list[Instruction]]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "signers",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "lookup_tables",
+                "kind": "positional_or_keyword",
+                "type": "list[AddressLookupTableAccount]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "tx_version",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Union[Legacy, int]]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "sequencer_subaccount",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "TxSigAndSlot"
+            },
+            "signature": "(self, ixs: Union[Instruction, list[Instruction]], signers = None, lookup_tables: list[AddressLookupTableAccount] = None, tx_version: Optional[Union[Legacy, int]] = None, sequencer_subaccount: Optional[int] = None) -> TxSigAndSlot"
+          },
+          {
+            "name": "settle_expired_market",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int)"
+          },
+          {
+            "name": "settle_lp",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "settlee_user_account_public_key",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Signature"
+            },
+            "signature": "(self, settlee_user_account_public_key: Pubkey, market_index: int) -> Signature"
+          },
+          {
+            "name": "settle_pnl",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "settlee_user_account_public_key",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "settlee_user_account",
+                "kind": "positional_or_keyword",
+                "type": "UserAccount",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, settlee_user_account_public_key: Pubkey, settlee_user_account: UserAccount, market_index: int)"
+          },
+          {
+            "name": "settle_revenue_to_insurance_fund",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_market_index: int)"
+          },
+          {
+            "name": "sign_message",
+            "is_async": false,
+            "docstring": "Sign a message with the wallet keypair.\n\nArgs:\n    message: The message to sign\n\nReturns:\n    The signature",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "message",
+                "kind": "positional_or_keyword",
+                "type": "bytes",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bytes"
+            },
+            "signature": "(self, message: bytes) -> bytes"
+          },
+          {
+            "name": "sign_signed_msg_order_params_message",
+            "is_async": false,
+            "docstring": "Sign a SignedMsgOrderParamsMessage\n\nArgs:\n    order_params_message: The order params message to sign\n    delegate_signer: Whether to use delegate message format\n\nReturns:\n    The signed order params",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_params_message",
+                "kind": "positional_or_keyword",
+                "type": "Union[dict, SignedMsgOrderParamsMessage, SignedMsgOrderParamsDelegateMessage]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "delegate_signer",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": "SignedMsgOrderParams"
+            },
+            "signature": "(self, order_params_message: Union[dict, SignedMsgOrderParamsMessage, SignedMsgOrderParamsDelegateMessage], delegate_signer: bool = False) -> SignedMsgOrderParams"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "switch_active_user",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, sub_account_id: int)"
+          },
+          {
+            "name": "transfer_deposit",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "from_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "to_sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, amount: int, market_index: int, from_sub_account_id: int, to_sub_account_id: int)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "update_amm",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_indexs",
+                "kind": "positional_or_keyword",
+                "type": "list[int]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_indexs: list[int])"
+          },
+          {
+            "name": "update_prelaunch_oracle",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_index: int)"
+          },
+          {
+            "name": "update_user_margin_trading_enabled",
+            "is_async": true,
+            "docstring": "Toggles margin trading for a user\n\nArgs:\n    sub_account_id (int, optional): subaccount id. Defaults to 0.\n\nReturns:\n    Signature: tx sig",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "margin_trading_enabled",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "Signature"
+            },
+            "signature": "(self, margin_trading_enabled: bool, sub_account_id: Optional[int] = None) -> Signature"
+          },
+          {
+            "name": "update_user_protected_maker_orders",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "protected_orders",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, sub_account_id: int, protected_orders: bool)"
+          },
+          {
+            "name": "withdraw",
+            "is_async": true,
+            "docstring": "withdraws from drift protocol (can also allow borrowing)\n\nArgs:\n    amount (int): amount to withdraw\n    market_index (int):\n    user_token_account (Pubkey): ata of the account to withdraw to\n    reduce_only (bool, optional): if True will only withdraw existing funds else if False will allow taking out borrows. Defaults to False.\n    sub_account_id (int, optional): subaccount. Defaults to 0.\n\nReturns:\n    str: tx sig",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_token_account",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "reduce_only",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "False"
+              },
+              {
+                "name": "sub_account_id",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "TxSigAndSlot"
+            },
+            "signature": "(self, amount: int, market_index: int, user_token_account: Pubkey, reduce_only: bool = False, sub_account_id: int = None) -> TxSigAndSlot"
+          }
+        ]
+      },
+      {
+        "name": "JitoParams",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.drift_user_stats",
+    "path": "drift_user_stats.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "DriftUserStats",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "drift_client",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_stats_account_pubkey",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "config",
+                "kind": "positional_or_keyword",
+                "type": "UserStatsSubscriptionConfig",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, drift_client, user_stats_account_pubkey: Pubkey, config: UserStatsSubscriptionConfig)"
+          },
+          {
+            "name": "fetch_accounts",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get_account",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "UserStatsAccount"
+            },
+            "signature": "(self) -> UserStatsAccount"
+          },
+          {
+            "name": "get_account_and_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "DataAndSlot[UserStatsAccount]"
+            },
+            "signature": "(self) -> DataAndSlot[UserStatsAccount]"
+          },
+          {
+            "name": "get_referrer_info",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[ReferrerInfo]"
+            },
+            "signature": "(self) -> Optional[ReferrerInfo]"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self) -> bool"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      },
+      {
+        "name": "UserStatsSubscriptionConfig",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.events.event_list",
+    "path": "events/event_list.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "EventList",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "max_size",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "sort_fn",
+                "kind": "positional_or_keyword",
+                "type": "SortFn",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_direction",
+                "kind": "positional_or_keyword",
+                "type": "EventSubscriptionOrderDirection",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, max_size: int, sort_fn: SortFn, order_direction: EventSubscriptionOrderDirection)"
+          },
+          {
+            "name": "detach",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self) -> None"
+          },
+          {
+            "name": "insert",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "event",
+                "kind": "positional_or_keyword",
+                "type": "WrappedEvent",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, event: WrappedEvent) -> None"
+          },
+          {
+            "name": "to_array",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "list[WrappedEvent]"
+            },
+            "signature": "(self) -> list[WrappedEvent]"
+          }
+        ]
+      },
+      {
+        "name": "Node",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.events.event_subscriber",
+    "path": "events/event_subscriber.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "EventSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "connection",
+                "kind": "positional_or_keyword",
+                "type": "AsyncClient",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "program",
+                "kind": "positional_or_keyword",
+                "type": "Program",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "options",
+                "kind": "positional_or_keyword",
+                "type": "EventSubscriptionOptions",
+                "required": false,
+                "default": "EventSubscriptionOptions.default()"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, connection: AsyncClient, program: Program, options: EventSubscriptionOptions = EventSubscriptionOptions.default())"
+          },
+          {
+            "name": "get_event_list",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "event_type",
+                "kind": "positional_or_keyword",
+                "type": "EventType",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[EventList]"
+            },
+            "signature": "(self, event_type: EventType) -> Optional[EventList]"
+          },
+          {
+            "name": "get_events_array",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "event_type",
+                "kind": "positional_or_keyword",
+                "type": "EventType",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[list[WrappedEvent]]"
+            },
+            "signature": "(self, event_type: EventType) -> Optional[list[WrappedEvent]]"
+          },
+          {
+            "name": "get_events_by_tx",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "tx_sig",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[list[WrappedEvent]]"
+            },
+            "signature": "(self, tx_sig: str) -> Optional[list[WrappedEvent]]"
+          },
+          {
+            "name": "handle_tx_logs",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "tx_sig",
+                "kind": "positional_or_keyword",
+                "type": "Signature",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "logs",
+                "kind": "positional_or_keyword",
+                "type": "list[str]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, tx_sig: Signature, slot: int, logs: list[str])"
+          },
+          {
+            "name": "parse_events_from_logs",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "tx_sig",
+                "kind": "positional_or_keyword",
+                "type": "Signature",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "logs",
+                "kind": "positional_or_keyword",
+                "type": "list[str]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, tx_sig: Signature, slot: int, logs: list[str])"
+          },
+          {
+            "name": "subscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.events.fetch_logs",
+    "path": "events/fetch_logs.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "chunk",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "array",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "size",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(array, size)"
+      },
+      {
+        "name": "fetch_logs",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "connection",
+            "kind": "positional_or_keyword",
+            "type": "AsyncClient",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "address",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "commitment",
+            "kind": "positional_or_keyword",
+            "type": "Commitment",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "before_tx",
+            "kind": "positional_or_keyword",
+            "type": "Signature",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "until_tx",
+            "kind": "positional_or_keyword",
+            "type": "Signature",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "limit",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "batch_size",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "returns": {
+          "type": "list[Signature, int, list[str]]"
+        },
+        "signature": "(connection: AsyncClient, address: Pubkey, commitment: Commitment, before_tx: Signature = None, until_tx: Signature = None, limit: int = None, batch_size: int = None) -> list[Signature, int, list[str]]"
+      },
+      {
+        "name": "fetch_transactions",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "connection",
+            "kind": "positional_or_keyword",
+            "type": "AsyncClient",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "signatures",
+            "kind": "positional_or_keyword",
+            "type": "list[RpcConfirmedTransactionStatusWithSignature]",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "commitment",
+            "kind": "positional_or_keyword",
+            "type": "Commitment",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "list[Signature, int, list[str]]"
+        },
+        "signature": "(connection: AsyncClient, signatures: list[RpcConfirmedTransactionStatusWithSignature], commitment: Commitment) -> list[Signature, int, list[str]]"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.events.grpc_log_provider",
+    "path": "events/grpc_log_provider.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "GrpcLogProvider",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "grpc_config",
+                "kind": "positional_or_keyword",
+                "type": "GrpcLogProviderConfig",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "commitment",
+                "kind": "positional_or_keyword",
+                "type": "Commitment",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account_to_filter",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Pubkey]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "program_id",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": false,
+                "default": "DRIFT_PROGRAM_ID"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, grpc_config: GrpcLogProviderConfig, commitment: Commitment, user_account_to_filter: Optional[Pubkey] = None, program_id: Pubkey = DRIFT_PROGRAM_ID)"
+          },
+          {
+            "name": "is_subscribed",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self) -> bool"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "callback",
+                "kind": "positional_or_keyword",
+                "type": "LogProviderCallback",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, callback: LogProviderCallback)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.events.parse",
+    "path": "events/parse.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "DRIFT_PROGRAM_ID"
+      },
+      {
+        "name": "DRIFT_PROGRAM_START"
+      },
+      {
+        "name": "PROGRAM_DATA"
+      },
+      {
+        "name": "PROGRAM_DATA_START_INDEX"
+      },
+      {
+        "name": "PROGRAM_LOG"
+      },
+      {
+        "name": "PROGRAM_LOG_START_INDEX"
+      }
+    ],
+    "functions": [
+      {
+        "name": "handle_log",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "execution",
+            "kind": "positional_or_keyword",
+            "type": "ExecutionContext",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "log",
+            "kind": "positional_or_keyword",
+            "type": "str",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Tuple[Optional[Event], Optional[str], bool]"
+        },
+        "signature": "(execution: ExecutionContext, log: str, program: Program) -> Tuple[Optional[Event], Optional[str], bool]"
+      },
+      {
+        "name": "handle_program_log",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "log",
+            "kind": "positional_or_keyword",
+            "type": "str",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Tuple[Optional[Event], Optional[str], bool]"
+        },
+        "signature": "(log: str, program: Program) -> Tuple[Optional[Event], Optional[str], bool]"
+      },
+      {
+        "name": "handle_system_log",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "log",
+            "kind": "positional_or_keyword",
+            "type": "str",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Tuple[Optional[str], bool]"
+        },
+        "signature": "(log: str) -> Tuple[Optional[str], bool]"
+      },
+      {
+        "name": "parse_logs",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "logs",
+            "kind": "positional_or_keyword",
+            "type": "list[str]",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "list[Event]"
+        },
+        "signature": "(program: Program, logs: list[str]) -> list[Event]"
+      }
+    ],
+    "classes": [
+      {
+        "name": "ExecutionContext",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "pop",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "program",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "push",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "program",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, program: str)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.events.polling_log_provider",
+    "path": "events/polling_log_provider.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "PollingLogProvider",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "connection",
+                "kind": "positional_or_keyword",
+                "type": "AsyncClient",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "address",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "commitment",
+                "kind": "positional_or_keyword",
+                "type": "Commitment",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "frequency",
+                "kind": "positional_or_keyword",
+                "type": "float",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "batch_size",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "25"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, connection: AsyncClient, address: Pubkey, commitment: Commitment, frequency: float, batch_size: int = 25)"
+          },
+          {
+            "name": "is_subscribed",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self) -> bool"
+          },
+          {
+            "name": "subscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "callback",
+                "kind": "positional_or_keyword",
+                "type": "LogProviderCallback",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, callback: LogProviderCallback)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.events.sort",
+    "path": "events/sort.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "blockchain_sort_fn",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "current_event",
+            "kind": "positional_or_keyword",
+            "type": "WrappedEvent",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "new_event",
+            "kind": "positional_or_keyword",
+            "type": "WrappedEvent",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(current_event: WrappedEvent, new_event: WrappedEvent) -> int"
+      },
+      {
+        "name": "client_sort_asc_fn",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "() -> int"
+      },
+      {
+        "name": "client_sort_desc_fn",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "() -> int"
+      },
+      {
+        "name": "get_sort_fn",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order_by",
+            "kind": "positional_or_keyword",
+            "type": "EventSubscriptionOrderBy",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "order_dir",
+            "kind": "positional_or_keyword",
+            "type": "EventSubscriptionOrderDirection",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "SortFn"
+        },
+        "signature": "(order_by: EventSubscriptionOrderBy, order_dir: EventSubscriptionOrderDirection) -> SortFn"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.events.tx_event_cache",
+    "path": "events/tx_event_cache.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "Node",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "TxEventCache",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "max_tx",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "1024"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, max_tx: int = 1024)"
+          },
+          {
+            "name": "add",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "key",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "events",
+                "kind": "positional_or_keyword",
+                "type": "List[WrappedEvent]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, key: str, events: List[WrappedEvent]) -> None"
+          },
+          {
+            "name": "clear",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self) -> None"
+          },
+          {
+            "name": "detach",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "node",
+                "kind": "positional_or_keyword",
+                "type": "Node",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, node: Node) -> None"
+          },
+          {
+            "name": "get",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "key",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[List[WrappedEvent]]"
+            },
+            "signature": "(self, key: str) -> Optional[List[WrappedEvent]]"
+          },
+          {
+            "name": "has",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "key",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self, key: str) -> bool"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.events.types",
+    "path": "events/types.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "DEFAULT_EVENT_TYPES"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "EventSubscriptionOptions",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "default",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [],
+            "returns": {
+              "type": null
+            },
+            "signature": "()"
+          },
+          {
+            "name": "get_log_provider",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "connection",
+                "kind": "positional_or_keyword",
+                "type": "AsyncClient",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, connection: AsyncClient)"
+          }
+        ]
+      },
+      {
+        "name": "LogProvider",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "is_subscribed",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "subscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "callback",
+                "kind": "positional_or_keyword",
+                "type": "LogProviderCallback",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self, callback: LogProviderCallback) -> bool"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      },
+      {
+        "name": "PollingLogProviderConfig",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "WebsocketLogProviderConfig",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "WrappedEvent",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.events.websocket_log_provider",
+    "path": "events/websocket_log_provider.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "WebsocketLogProvider",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "connection",
+                "kind": "positional_or_keyword",
+                "type": "AsyncClient",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "address",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "commitment",
+                "kind": "positional_or_keyword",
+                "type": "Commitment",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, connection: AsyncClient, address: Pubkey, commitment: Commitment)"
+          },
+          {
+            "name": "is_subscribed",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self) -> bool"
+          },
+          {
+            "name": "subscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "callback",
+                "kind": "positional_or_keyword",
+                "type": "LogProviderCallback",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, callback: LogProviderCallback)"
+          },
+          {
+            "name": "subscribe_ws",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "callback",
+                "kind": "positional_or_keyword",
+                "type": "LogProviderCallback",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, callback: LogProviderCallback)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.indicative_quotes.indicative_quotes_sender",
+    "path": "indicative_quotes/indicative_quotes_sender.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "SEND_INTERVAL"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "IndicativeQuotesSender",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "endpoint",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "keypair",
+                "kind": "positional_or_keyword",
+                "type": "Keypair",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, endpoint: str, keypair: Keypair)"
+          },
+          {
+            "name": "close",
+            "is_async": true,
+            "docstring": "Close connection and cleanup",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "connect",
+            "is_async": true,
+            "docstring": "Connect to WebSocket server",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "generate_challenge_response",
+            "is_async": false,
+            "docstring": "Generate signature for authentication challenge",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "nonce",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "str"
+            },
+            "signature": "(self, nonce: str) -> str"
+          },
+          {
+            "name": "handle_auth_message",
+            "is_async": true,
+            "docstring": "Handle authentication messages from server",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "message",
+                "kind": "positional_or_keyword",
+                "type": "dict",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, message: dict)"
+          },
+          {
+            "name": "set_quote",
+            "is_async": false,
+            "docstring": "Set or update a quote for a market",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "quote",
+                "kind": "positional_or_keyword",
+                "type": "Quote",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, quote: Quote)"
+          }
+        ]
+      },
+      {
+        "name": "Quote",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "bid_price",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "ask_price",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "bid_base_asset_amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "ask_base_asset_amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "is_oracle_offset",
+                "kind": "positional_or_keyword",
+                "type": "Optional[bool]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, bid_price: int, ask_price: int, bid_base_asset_amount: int, ask_base_asset_amount: int, market_index: int, is_oracle_offset: Optional[bool] = None)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.keypair",
+    "path": "keypair.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "load_keypair",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "private_key",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(private_key)"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.market_map.grpc_market_map",
+    "path": "market_map/grpc_market_map.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "T"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "GrpcMarketMap",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "config",
+                "kind": "positional_or_keyword",
+                "type": "GrpcMarketMapConfig",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, config: GrpcMarketMapConfig)"
+          },
+          {
+            "name": "add_market",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "data",
+                "kind": "positional_or_keyword",
+                "type": "DataAndSlot[T]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, market_index: int, data: DataAndSlot[T]) -> None"
+          },
+          {
+            "name": "clear",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "dump",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "raw",
+                "kind": "positional_or_keyword",
+                "type": "dict[str, bytes]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "filename",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, raw: dict[str, bytes], filename: Optional[str] = None)"
+          },
+          {
+            "name": "get",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "key",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[T]"
+            },
+            "signature": "(self, key: int) -> Optional[T]"
+          },
+          {
+            "name": "get_last_dump_filepath",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "str"
+            },
+            "signature": "(self) -> str"
+          },
+          {
+            "name": "has",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "key",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self, key: int) -> bool"
+          },
+          {
+            "name": "init",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_ds",
+                "kind": "positional_or_keyword",
+                "type": "list[DataAndSlot[T]]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_ds: list[DataAndSlot[T]])"
+          },
+          {
+            "name": "load",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "filename",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, filename: Optional[str] = None)"
+          },
+          {
+            "name": "must_get",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "key",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "data",
+                "kind": "positional_or_keyword",
+                "type": "DataAndSlot[T]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[T]"
+            },
+            "signature": "(self, key: int, data: DataAndSlot[T]) -> Optional[T]"
+          },
+          {
+            "name": "pre_dump",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "dict[str, bytes]"
+            },
+            "signature": "(self) -> dict[str, bytes]"
+          },
+          {
+            "name": "size",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self) -> int"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "update_market",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "_key",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "data",
+                "kind": "positional_or_keyword",
+                "type": "DataAndSlot[T]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, _key: str, data: DataAndSlot[T]) -> None"
+          },
+          {
+            "name": "values",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.market_map.grpc_sub",
+    "path": "market_map/grpc_sub.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "T"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "GrpcSubscription",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "grpc_config",
+                "kind": "positional_or_keyword",
+                "type": "GrpcConfig",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_map",
+                "kind": "positional_or_keyword",
+                "type": "MarketMap",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "commitment",
+                "kind": "positional_or_keyword",
+                "type": "Commitment",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "on_update",
+                "kind": "positional_or_keyword",
+                "type": "MarketUpdateCallback",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "decode",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Callable[[bytes], T]]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, grpc_config: GrpcConfig, market_map: MarketMap, commitment: Commitment, on_update: MarketUpdateCallback, decode: Optional[Callable[[bytes], T]] = None)"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.market_map.market_map",
+    "path": "market_map/market_map.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "T"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "MarketMap",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "config",
+                "kind": "positional_or_keyword",
+                "type": "MarketMapConfig",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, config: MarketMapConfig)"
+          },
+          {
+            "name": "add_market",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "data",
+                "kind": "positional_or_keyword",
+                "type": "DataAndSlot[GenericMarketType]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, market_index: int, data: DataAndSlot[GenericMarketType]) -> None"
+          },
+          {
+            "name": "clear",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "dump",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "raw",
+                "kind": "positional_or_keyword",
+                "type": "dict[str, bytes]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "filename",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, raw: dict[str, bytes], filename: Optional[str] = None)"
+          },
+          {
+            "name": "get",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "key",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[GenericMarketType]"
+            },
+            "signature": "(self, key: int) -> Optional[GenericMarketType]"
+          },
+          {
+            "name": "get_last_dump_filepath",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "str"
+            },
+            "signature": "(self) -> str"
+          },
+          {
+            "name": "has",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "key",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self, key: int) -> bool"
+          },
+          {
+            "name": "init",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_ds",
+                "kind": "positional_or_keyword",
+                "type": "list[DataAndSlot[GenericMarketType]]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_ds: list[DataAndSlot[GenericMarketType]])"
+          },
+          {
+            "name": "load",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "filename",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, filename: Optional[str] = None)"
+          },
+          {
+            "name": "must_get",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "key",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "data",
+                "kind": "positional_or_keyword",
+                "type": "DataAndSlot[GenericMarketType]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[GenericMarketType]"
+            },
+            "signature": "(self, key: int, data: DataAndSlot[GenericMarketType]) -> Optional[GenericMarketType]"
+          },
+          {
+            "name": "pre_dump",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "dict[str, bytes]"
+            },
+            "signature": "(self) -> dict[str, bytes]"
+          },
+          {
+            "name": "size",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self) -> int"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "update_market",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "_key",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "data",
+                "kind": "positional_or_keyword",
+                "type": "DataAndSlot[GenericMarketType]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, _key: str, data: DataAndSlot[GenericMarketType]) -> None"
+          },
+          {
+            "name": "values",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.market_map.market_map_config",
+    "path": "market_map/market_map_config.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "GrpcMarketMapConfig",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "MarketMapConfig",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "WebsocketConfig",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.market_map.websocket_sub",
+    "path": "market_map/websocket_sub.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "T"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "WebsocketSubscription",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_map",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "commitment",
+                "kind": "positional_or_keyword",
+                "type": "Commitment",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "on_update",
+                "kind": "positional_or_keyword",
+                "type": "MarketUpdateCallback",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "resub_timeout_ms",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "decode",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Callable[[bytes], T]]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, market_map, commitment: Commitment, on_update: MarketUpdateCallback, resub_timeout_ms: Optional[int] = None, decode: Optional[Callable[[bytes], T]] = None)"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.math.amm",
+    "path": "math/amm.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "calculate_amm_reserves_after_swap",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amm",
+            "kind": "positional_or_keyword",
+            "type": "AMM",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "input_asset_type",
+            "kind": "positional_or_keyword",
+            "type": "AssetType",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "swap_amount",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "swap_direction",
+            "kind": "positional_or_keyword",
+            "type": "SwapDirection",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(amm: AMM, input_asset_type: AssetType, swap_amount: int, swap_direction: SwapDirection)"
+      },
+      {
+        "name": "calculate_bid_ask_price",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amm",
+            "kind": "positional_or_keyword",
+            "type": "AMM",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "with_update",
+            "kind": "positional_or_keyword",
+            "type": "bool",
+            "required": false,
+            "default": "True"
+          },
+          {
+            "name": "is_prediction",
+            "kind": "positional_or_keyword",
+            "type": "bool",
+            "required": false,
+            "default": "False"
+          }
+        ],
+        "returns": {
+          "type": "tuple[int, int]"
+        },
+        "signature": "(amm: AMM, oracle_price_data: OraclePriceData, with_update: bool = True, is_prediction: bool = False) -> tuple[int, int]"
+      },
+      {
+        "name": "calculate_effective_leverage",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "base_spread",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "quote_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "terminal_quote_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "peg_multiplier",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "net_base_asset_amount",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "reserve_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "total_fee_minus_distributions",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(base_spread: int, quote_asset_reserve: int, terminal_quote_asset_reserve: int, peg_multiplier: int, net_base_asset_amount: int, reserve_price: int, total_fee_minus_distributions: int) -> int"
+      },
+      {
+        "name": "calculate_inventory_liquidity_ratio",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "base_asset_amount_with_amm",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "base_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "min_base_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "max_base_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(base_asset_amount_with_amm: int, base_asset_reserve: int, min_base_asset_reserve: int, max_base_asset_reserve: int) -> int"
+      },
+      {
+        "name": "calculate_inventory_liquidity_ratio_for_reference_price_offset",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "base_asset_amount_with_amm",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "base_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "min_base_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "max_base_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(base_asset_amount_with_amm: int, base_asset_reserve: int, min_base_asset_reserve: int, max_base_asset_reserve: int) -> int"
+      },
+      {
+        "name": "calculate_inventory_scale",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "base_asset_amount_with_amm",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "base_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "min_base_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "max_base_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "directional_spread",
+            "kind": "positional_or_keyword",
+            "type": "float",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "max_spread",
+            "kind": "positional_or_keyword",
+            "type": "float",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "float"
+        },
+        "signature": "(base_asset_amount_with_amm: int, base_asset_reserve: int, min_base_asset_reserve: int, max_base_asset_reserve: int, directional_spread: float, max_spread: float) -> float"
+      },
+      {
+        "name": "calculate_market_open_bid_ask",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "base_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "min_base_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "max_base_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "step_size",
+            "kind": "positional_or_keyword",
+            "type": "Optional[int]",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(base_asset_reserve: int, min_base_asset_reserve: int, max_base_asset_reserve: int, step_size: Optional[int] = None)"
+      },
+      {
+        "name": "calculate_max_base_asset_amount_to_trade",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amm",
+            "kind": "positional_or_keyword",
+            "type": "AMM",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "limit_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "direction",
+            "kind": "positional_or_keyword",
+            "type": "PositionDirection",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "now",
+            "kind": "positional_or_keyword",
+            "type": "Optional[int]",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "is_prediction",
+            "kind": "positional_or_keyword",
+            "type": "bool",
+            "required": false,
+            "default": "False"
+          }
+        ],
+        "returns": {
+          "type": "tuple[int, PositionDirection]"
+        },
+        "signature": "(amm: AMM, limit_price: int, direction: PositionDirection, oracle_price_data: OraclePriceData, now: Optional[int] = None, is_prediction: bool = False) -> tuple[int, PositionDirection]"
+      },
+      {
+        "name": "calculate_new_amm",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amm",
+            "kind": "positional_or_keyword",
+            "type": "AMM",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(amm: AMM, oracle_price_data: OraclePriceData)"
+      },
+      {
+        "name": "calculate_peg_from_target_price",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "target_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "base_asset_reserves",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "quote_asset_reserves",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(target_price: int, base_asset_reserves: int, quote_asset_reserves: int) -> int"
+      },
+      {
+        "name": "calculate_price",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "base_asset_amount",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "quote_asset_amount",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "peg_multiplier",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(base_asset_amount: int, quote_asset_amount: int, peg_multiplier: int)"
+      },
+      {
+        "name": "calculate_quote_asset_amount_swapped",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "quote_asset_reserves",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "peg_multiplier",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "swap_direction",
+            "kind": "positional_or_keyword",
+            "type": "SwapDirection",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(quote_asset_reserves: int, peg_multiplier: int, swap_direction: SwapDirection) -> int"
+      },
+      {
+        "name": "calculate_reference_price_offset",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "reserve_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "last_24h_avg_funding_rate",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "liquidity_fraction",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_twap_fast",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "mark_twap_fast",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_twap_slow",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "mark_twap_slow",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "max_offset_pct",
+            "kind": "positional_or_keyword",
+            "type": "float",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(reserve_price: int, last_24h_avg_funding_rate: int, liquidity_fraction: int, oracle_twap_fast: int, mark_twap_fast: int, oracle_twap_slow: int, mark_twap_slow: int, max_offset_pct: float)"
+      },
+      {
+        "name": "calculate_spread",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amm",
+            "kind": "positional_or_keyword",
+            "type": "AMM",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "now",
+            "kind": "positional_or_keyword",
+            "type": "Optional[int]",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "reserve_price",
+            "kind": "positional_or_keyword",
+            "type": "Optional[int]",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "returns": {
+          "type": "tuple[float, float]"
+        },
+        "signature": "(amm: AMM, oracle_price_data: OraclePriceData, now: Optional[int] = None, reserve_price: Optional[int] = None) -> tuple[float, float]"
+      },
+      {
+        "name": "calculate_spread_bn",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "base_spread",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "last_oracle_reserve_price_spread_pct",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "last_oracle_conf_pct",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "max_spread",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "quote_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "terminal_quote_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "peg_multiplier",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "base_asset_amount_with_amm",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "reserve_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "total_fee_minus_distributions",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "net_revenue_since_last_funding",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "base_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "min_base_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "max_base_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "mark_std",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_std",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "long_intensity",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "short_intensity",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "volume24H",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "amm_inventory_spread_adjustment",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": false,
+            "default": "0"
+          },
+          {
+            "name": "return_terms",
+            "kind": "positional_or_keyword",
+            "type": "bool",
+            "required": false,
+            "default": "False"
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(base_spread: int, last_oracle_reserve_price_spread_pct: int, last_oracle_conf_pct: int, max_spread: int, quote_asset_reserve: int, terminal_quote_asset_reserve: int, peg_multiplier: int, base_asset_amount_with_amm: int, reserve_price: int, total_fee_minus_distributions: int, net_revenue_since_last_funding: int, base_asset_reserve: int, min_base_asset_reserve: int, max_base_asset_reserve: int, mark_std: int, oracle_std: int, long_intensity: int, short_intensity: int, volume24H: int, amm_inventory_spread_adjustment: int = 0, return_terms: bool = False)"
+      },
+      {
+        "name": "calculate_spread_reserves",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amm",
+            "kind": "positional_or_keyword",
+            "type": "AMM",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "now",
+            "kind": "positional_or_keyword",
+            "type": "Optional[int]",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "is_prediction",
+            "kind": "positional_or_keyword",
+            "type": "bool",
+            "required": false,
+            "default": "False"
+          },
+          {
+            "name": "latest_slot",
+            "kind": "positional_or_keyword",
+            "type": "Optional[int]",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "returns": {
+          "type": "Tuple[int, int]"
+        },
+        "signature": "(amm: AMM, oracle_price_data: OraclePriceData, now: Optional[int] = None, is_prediction: bool = False, latest_slot: Optional[int] = None) -> Tuple[int, int]"
+      },
+      {
+        "name": "calculate_swap_output",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "input_asset_reserve",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "swap_amount",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "swap_direction",
+            "kind": "positional_or_keyword",
+            "type": "SwapDirection",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "invariant",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(input_asset_reserve: int, swap_amount: int, swap_direction: SwapDirection, invariant: int)"
+      },
+      {
+        "name": "calculate_updated_amm",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amm",
+            "kind": "positional_or_keyword",
+            "type": "AMM",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "AMM"
+        },
+        "signature": "(amm: AMM, oracle_price_data: OraclePriceData) -> AMM"
+      },
+      {
+        "name": "calculate_updated_amm_spread_reserves",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amm",
+            "kind": "positional_or_keyword",
+            "type": "AMM",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "direction",
+            "kind": "positional_or_keyword",
+            "type": "PositionDirection",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "is_prediction",
+            "kind": "positional_or_keyword",
+            "type": "bool",
+            "required": false,
+            "default": "False"
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(amm: AMM, direction: PositionDirection, oracle_price_data: OraclePriceData, is_prediction: bool = False)"
+      },
+      {
+        "name": "calculate_vol_spread_bn",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "last_oracle_conf_pct",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "reserve_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "mark_std",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_std",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "long_intensity",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "short_intensity",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "volume_24h",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(last_oracle_conf_pct: int, reserve_price: int, mark_std: int, oracle_std: int, long_intensity: int, short_intensity: int, volume_24h: int)"
+      },
+      {
+        "name": "deepcopy_amm",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amm",
+            "kind": "positional_or_keyword",
+            "type": "AMM",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "AMM"
+        },
+        "signature": "(amm: AMM) -> AMM"
+      },
+      {
+        "name": "get_quote_asset_reserve_prediction_market_bounds",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amm",
+            "kind": "positional_or_keyword",
+            "type": "AMM",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "direction",
+            "kind": "positional_or_keyword",
+            "type": "PositionDirection",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Tuple[int, int]"
+        },
+        "signature": "(amm: AMM, direction: PositionDirection) -> Tuple[int, int]"
+      },
+      {
+        "name": "get_swap_direction",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "input_asset_type",
+            "kind": "positional_or_keyword",
+            "type": "AssetType",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "position_direction",
+            "kind": "positional_or_keyword",
+            "type": "PositionDirection",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "SwapDirection"
+        },
+        "signature": "(input_asset_type: AssetType, position_direction: PositionDirection) -> SwapDirection"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.math.auction",
+    "path": "math/auction.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "derive_oracle_auction_params",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "direction",
+            "kind": "positional_or_keyword",
+            "type": "PositionDirection",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "auction_start_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "auction_end_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "limit_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Tuple[int, int, int]"
+        },
+        "signature": "(direction: PositionDirection, oracle_price: int, auction_start_price: int, auction_end_price: int, limit_price: int) -> Tuple[int, int, int]"
+      },
+      {
+        "name": "get_auction_price",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order",
+            "kind": "positional_or_keyword",
+            "type": "Order",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "slot",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(order: Order, slot: int, oracle_price: int) -> int"
+      },
+      {
+        "name": "get_auction_price_for_fixed_auction",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order",
+            "kind": "positional_or_keyword",
+            "type": "Order",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "slot",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(order: Order, slot: int) -> int"
+      },
+      {
+        "name": "get_auction_price_for_oracle_offset_auction",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order",
+            "kind": "positional_or_keyword",
+            "type": "Order",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "slot",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(order: Order, slot: int, oracle_price: int) -> int"
+      },
+      {
+        "name": "is_auction_complete",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order",
+            "kind": "positional_or_keyword",
+            "type": "Order",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "slot",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(order: Order, slot: int) -> bool"
+      },
+      {
+        "name": "is_fallback_available_liquidity_source",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order",
+            "kind": "positional_or_keyword",
+            "type": "Order",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "min_auction_duration",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "slot",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(order: Order, min_auction_duration: int, slot: int) -> bool"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.math.conversion",
+    "path": "math/conversion.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "convert_to_number",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "big_number",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "precision",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": false,
+            "default": "PRICE_PRECISION"
+          }
+        ],
+        "returns": {
+          "type": "float"
+        },
+        "signature": "(big_number: int, precision: int = PRICE_PRECISION) -> float"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.math.exchange_status",
+    "path": "math/exchange_status.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "amm_paused",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "state",
+            "kind": "positional_or_keyword",
+            "type": "StateAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "Union[PerpMarketAccount, SpotMarketAccount]",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(state: StateAccount, market: Union[PerpMarketAccount, SpotMarketAccount]) -> bool"
+      },
+      {
+        "name": "exchange_paused",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "state",
+            "kind": "positional_or_keyword",
+            "type": "StateAccount",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(state: StateAccount) -> bool"
+      },
+      {
+        "name": "fill_paused",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "state",
+            "kind": "positional_or_keyword",
+            "type": "StateAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "Union[PerpMarketAccount, SpotMarketAccount]",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(state: StateAccount, market: Union[PerpMarketAccount, SpotMarketAccount]) -> bool"
+      }
+    ],
+    "classes": [
+      {
+        "name": "ExchangeStatusValues",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.math.fuel",
+    "path": "math/fuel.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "calculate_insurance_fuel_bonus",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "spot_market",
+            "kind": "positional_or_keyword",
+            "type": "SpotMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "token_stake_amount",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "fuel_bonus_numerator",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(spot_market: SpotMarketAccount, token_stake_amount: int, fuel_bonus_numerator: int) -> int"
+      },
+      {
+        "name": "calculate_perp_fuel_bonus",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "perp_market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "base_asset_value",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "fuel_bonus_numerator",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(perp_market: PerpMarketAccount, base_asset_value: int, fuel_bonus_numerator: int) -> int"
+      },
+      {
+        "name": "calculate_spot_fuel_bonus",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "spot_market",
+            "kind": "positional_or_keyword",
+            "type": "SpotMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "signed_token_value",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "fuel_bonus_numerator",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(spot_market: SpotMarketAccount, signed_token_value: int, fuel_bonus_numerator: int) -> int"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.math.funding",
+    "path": "math/funding.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "calculate_all_estimated_funding_rate",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "Optional[OraclePriceData]",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "mark_price",
+            "kind": "positional_or_keyword",
+            "type": "Optional[int]",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "now",
+            "kind": "positional_or_keyword",
+            "type": "Optional[int]",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(market: PerpMarketAccount, oracle_price_data: Optional[OraclePriceData], mark_price: Optional[int] = None, now: Optional[int] = None)"
+      },
+      {
+        "name": "calculate_funding_fee_pool",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(market: PerpMarketAccount)"
+      },
+      {
+        "name": "calculate_funding_pool",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(market: PerpMarketAccount)"
+      },
+      {
+        "name": "calculate_live_mark_twap",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "mark_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "now",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "period",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": false,
+            "default": "3600"
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(market: PerpMarketAccount, oracle_price_data: OraclePriceData = None, mark_price: int = None, now: int = None, period: int = 3600) -> int"
+      },
+      {
+        "name": "calculate_long_short_funding",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "Optional[OraclePriceData]",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "mark_price",
+            "kind": "positional_or_keyword",
+            "type": "Optional[OraclePriceData]",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "now",
+            "kind": "positional_or_keyword",
+            "type": "Optional[int]",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "returns": {
+          "type": "Tuple[int, int]"
+        },
+        "signature": "(market: PerpMarketAccount, oracle_price_data: Optional[OraclePriceData] = None, mark_price: Optional[OraclePriceData] = None, now: Optional[int] = None) -> Tuple[int, int]"
+      },
+      {
+        "name": "calculate_long_short_funding_and_live_twaps",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "mark_price",
+            "kind": "positional_or_keyword",
+            "type": "Optional[int]",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "now",
+            "kind": "positional_or_keyword",
+            "type": "Optional[int]",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(market: PerpMarketAccount, oracle_price_data: OraclePriceData, mark_price: Optional[int], now: Optional[int])"
+      },
+      {
+        "name": "calculate_oracle_mark_spread_owed",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(market: PerpMarketAccount)"
+      },
+      {
+        "name": "get_max_price_divergence_for_funding_rate",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_twap",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(market: PerpMarketAccount, oracle_twap: int) -> int"
+      },
+      {
+        "name": "shrink_stale_twaps",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "mark_twap_with_mantissa",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_twap_with_mantissa",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "now",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(market: PerpMarketAccount, mark_twap_with_mantissa: int, oracle_twap_with_mantissa: int, now: int = None)"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.math.market",
+    "path": "math/market.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "calculate_ask_price",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(market: PerpMarketAccount, oracle_price_data: OraclePriceData) -> int"
+      },
+      {
+        "name": "calculate_bid_price",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(market: PerpMarketAccount, oracle_price_data: OraclePriceData) -> int"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.math.oracles",
+    "path": "math/oracles.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "calculate_live_oracle_std",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amm",
+            "kind": "positional_or_keyword",
+            "type": "AMM",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "now",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(amm: AMM, oracle_price_data: OraclePriceData, now: int) -> int"
+      },
+      {
+        "name": "calculate_live_oracle_twap",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "hist_oracle_data",
+            "kind": "positional_or_keyword",
+            "type": "HistoricalOracleData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "now",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "period",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(hist_oracle_data: HistoricalOracleData, oracle_price_data: OraclePriceData, now: int, period: int) -> int"
+      },
+      {
+        "name": "get_max_confidence_interval_multiplier",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(market: PerpMarketAccount) -> int"
+      },
+      {
+        "name": "get_new_oracle_conf_pct",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amm",
+            "kind": "positional_or_keyword",
+            "type": "AMM",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "reserve_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "now",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(amm: AMM, oracle_price_data: OraclePriceData, reserve_price: int, now: int) -> int"
+      },
+      {
+        "name": "is_oracle_valid",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_guard_rails",
+            "kind": "positional_or_keyword",
+            "type": "OracleGuardRails",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "slot",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(market: PerpMarketAccount, oracle_price_data: OraclePriceData, oracle_guard_rails: OracleGuardRails, slot: int) -> bool"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.math.orders",
+    "path": "math/orders.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "calculate_base_asset_amount_for_amm_to_fulfill",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order",
+            "kind": "positional_or_keyword",
+            "type": "Order",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "slot",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(order: Order, market: PerpMarketAccount, oracle_price_data: OraclePriceData, slot: int) -> int"
+      },
+      {
+        "name": "calculate_base_asset_amount_to_fill_up_to_limit_price",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order",
+            "kind": "positional_or_keyword",
+            "type": "Order",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "amm",
+            "kind": "positional_or_keyword",
+            "type": "AMM",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "limit_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(order: Order, amm: AMM, limit_price: int, oracle_price_data: OraclePriceData) -> int"
+      },
+      {
+        "name": "calculate_max_base_asset_amount_fillable",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amm",
+            "kind": "positional_or_keyword",
+            "type": "AMM",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "order_direction",
+            "kind": "positional_or_keyword",
+            "type": "PositionDirection",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(amm: AMM, order_direction: PositionDirection) -> int"
+      },
+      {
+        "name": "get_limit_price",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order",
+            "kind": "positional_or_keyword",
+            "type": "Order",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "slot",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "fallback_price",
+            "kind": "positional_or_keyword",
+            "type": "Optional[int]",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(order: Order, oracle_price_data: OraclePriceData, slot: int, fallback_price: Optional[int] = None) -> int"
+      },
+      {
+        "name": "has_auction_price",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order",
+            "kind": "positional_or_keyword",
+            "type": "Order",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "slot",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(order: Order, slot: int) -> bool"
+      },
+      {
+        "name": "is_fillable_by_vamm",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order",
+            "kind": "positional_or_keyword",
+            "type": "Order",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "slot",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "ts",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "min_auction_duration",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(order: Order, market: PerpMarketAccount, oracle_price_data: OraclePriceData, slot: int, ts: int, min_auction_duration: int) -> bool"
+      },
+      {
+        "name": "is_limit_order",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order",
+            "kind": "positional_or_keyword",
+            "type": "Order",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(order: Order) -> bool"
+      },
+      {
+        "name": "is_market_order",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order",
+            "kind": "positional_or_keyword",
+            "type": "Order",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(order: Order) -> bool"
+      },
+      {
+        "name": "is_order_expired",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order",
+            "kind": "positional_or_keyword",
+            "type": "Order",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "ts",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "enforce_buffer",
+            "kind": "positional_or_keyword",
+            "type": "bool",
+            "required": false,
+            "default": "False"
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(order: Order, ts: int, enforce_buffer: bool = False) -> bool"
+      },
+      {
+        "name": "is_resting_limit_order",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order",
+            "kind": "positional_or_keyword",
+            "type": "Order",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "slot",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(order: Order, slot: int) -> bool"
+      },
+      {
+        "name": "is_taking_order",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order",
+            "kind": "positional_or_keyword",
+            "type": "Order",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "slot",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(order: Order, slot: int) -> bool"
+      },
+      {
+        "name": "is_triggered",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order",
+            "kind": "positional_or_keyword",
+            "type": "Order",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(order: Order) -> bool"
+      },
+      {
+        "name": "must_be_triggered",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "order",
+            "kind": "positional_or_keyword",
+            "type": "Order",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(order: Order) -> bool"
+      },
+      {
+        "name": "same_direction",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "lhs",
+            "kind": "positional_or_keyword",
+            "type": "PositionDirection",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "rhs",
+            "kind": "positional_or_keyword",
+            "type": "PositionDirection",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(lhs: PositionDirection, rhs: PositionDirection) -> bool"
+      },
+      {
+        "name": "standardize_base_asset_amount",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "base_asset_amount",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "step_size",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(base_asset_amount: int, step_size: int) -> int"
+      },
+      {
+        "name": "standardize_price",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "tick_size",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "direction",
+            "kind": "positional_or_keyword",
+            "type": "PositionDirection",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(price: int, tick_size: int, direction: PositionDirection) -> int"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.math.perp_position",
+    "path": "math/perp_position.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "calculate_base_asset_value",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "user_position",
+            "kind": "positional_or_keyword",
+            "type": "PerpPosition",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "float"
+        },
+        "signature": "(market: PerpMarketAccount, user_position: PerpPosition) -> float"
+      },
+      {
+        "name": "calculate_base_asset_value_with_oracle",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "perp_position",
+            "kind": "positional_or_keyword",
+            "type": "PerpPosition",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "include_open_orders",
+            "kind": "positional_or_keyword",
+            "type": "bool",
+            "required": false,
+            "default": "False"
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(market: PerpMarketAccount, perp_position: PerpPosition, oracle_price_data: OraclePriceData, include_open_orders: bool = False)"
+      },
+      {
+        "name": "calculate_entry_price",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market_position",
+            "kind": "positional_or_keyword",
+            "type": "PerpPosition",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(market_position: PerpPosition)"
+      },
+      {
+        "name": "calculate_perp_liability_value",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "base_asset_amount",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "is_prediction_market",
+            "kind": "positional_or_keyword",
+            "type": "bool",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(base_asset_amount: int, oracle_price: int, is_prediction_market: bool) -> int"
+      },
+      {
+        "name": "calculate_position_funding_pnl",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "perp_position",
+            "kind": "positional_or_keyword",
+            "type": "PerpPosition",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(market: PerpMarketAccount, perp_position: PerpPosition)"
+      },
+      {
+        "name": "calculate_position_pnl",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "perp_position",
+            "kind": "positional_or_keyword",
+            "type": "PerpPosition",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "with_funding",
+            "kind": "positional_or_keyword",
+            "type": "bool",
+            "required": false,
+            "default": "False"
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(market: PerpMarketAccount, perp_position: PerpPosition, oracle_price_data: OraclePriceData, with_funding: bool = False)"
+      },
+      {
+        "name": "calculate_position_pnl_with_oracle",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "perp_position",
+            "kind": "positional_or_keyword",
+            "type": "PerpPosition",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "with_funding",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": false,
+            "default": "False"
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(market: PerpMarketAccount, perp_position: PerpPosition, oracle_data: OraclePriceData, with_funding = False)"
+      },
+      {
+        "name": "calculate_worst_case_base_asset_amount",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "perp_position",
+            "kind": "positional_or_keyword",
+            "type": "PerpPosition",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "perp_market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(perp_position: PerpPosition, perp_market: PerpMarketAccount, oracle_price: int) -> int"
+      },
+      {
+        "name": "calculate_worst_case_perp_liability_value",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "perp_position",
+            "kind": "positional_or_keyword",
+            "type": "PerpPosition",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "perp_market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "dict[str, int]"
+        },
+        "signature": "(perp_position: PerpPosition, perp_market: PerpMarketAccount, oracle_price: int) -> dict[str, int]"
+      },
+      {
+        "name": "is_available",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "position",
+            "kind": "positional_or_keyword",
+            "type": "PerpPosition",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(position: PerpPosition)"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.math.repeg",
+    "path": "math/repeg.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "calculate_adjust_k_cost",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amm",
+            "kind": "positional_or_keyword",
+            "type": "AMM",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "numerator",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "denominator",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(amm: AMM, numerator: int, denominator: int) -> int"
+      },
+      {
+        "name": "calculate_budgeted_k",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "cost",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(market, cost)"
+      },
+      {
+        "name": "calculate_budgeted_peg",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amm",
+            "kind": "positional_or_keyword",
+            "type": "AMM",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "budget",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "target_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(amm: AMM, budget: int, target_price: int) -> int"
+      },
+      {
+        "name": "calculate_k_cost",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "p",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(market, p)"
+      },
+      {
+        "name": "calculate_optimal_peg_and_budget",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amm",
+            "kind": "positional_or_keyword",
+            "type": "AMM",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "tuple[int, int, int, bool]"
+        },
+        "signature": "(amm: AMM, oracle_price_data: OraclePriceData) -> tuple[int, int, int, bool]"
+      },
+      {
+        "name": "calculate_repeg_cost",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amm",
+            "kind": "positional_or_keyword",
+            "type": "AMM",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "new_peg",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(amm: AMM, new_peg: int) -> int"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.math.spot_balance",
+    "path": "math/spot_balance.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "calculate_borrow_rate",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "spot_market",
+            "kind": "positional_or_keyword",
+            "type": "SpotMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "delta",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": false,
+            "default": "0"
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(spot_market: SpotMarketAccount, delta: int = 0) -> int"
+      },
+      {
+        "name": "calculate_deposit_rate",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "spot_market",
+            "kind": "positional_or_keyword",
+            "type": "SpotMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "delta",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": false,
+            "default": "0"
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(spot_market: SpotMarketAccount, delta: int = 0)"
+      },
+      {
+        "name": "calculate_interest_rate",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "spot_market",
+            "kind": "positional_or_keyword",
+            "type": "SpotMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "delta",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": false,
+            "default": "0"
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(spot_market: SpotMarketAccount, delta: int = 0) -> int"
+      },
+      {
+        "name": "calculate_spot_market_borrow_capacity",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "SpotMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "target_borrow_rate",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Tuple[int, int]"
+        },
+        "signature": "(market: SpotMarketAccount, target_borrow_rate: int) -> Tuple[int, int]"
+      },
+      {
+        "name": "calculate_utilization",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "spot_market",
+            "kind": "positional_or_keyword",
+            "type": "SpotMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "delta",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": false,
+            "default": "0"
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(spot_market: SpotMarketAccount, delta: int = 0) -> int"
+      },
+      {
+        "name": "get_strict_token_value",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "token_amount",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "spot_decimals",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "strict_oracle_price",
+            "kind": "positional_or_keyword",
+            "type": "StrictOraclePrice",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(token_amount: int, spot_decimals: int, strict_oracle_price: StrictOraclePrice) -> int"
+      },
+      {
+        "name": "get_token_value",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "token_amount",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "spot_decimals",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "OraclePriceData",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(token_amount: int, spot_decimals: int, oracle_price_data: OraclePriceData) -> int"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.math.spot_market",
+    "path": "math/spot_market.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "cast_to_spot_precision",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amount",
+            "kind": "positional_or_keyword",
+            "type": "Union[float, int]",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "spot_market",
+            "kind": "positional_or_keyword",
+            "type": "SpotMarketAccount",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(amount: Union[float, int], spot_market: SpotMarketAccount) -> int"
+      },
+      {
+        "name": "get_signed_token_amount",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amount",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "balance_type",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(amount, balance_type)"
+      },
+      {
+        "name": "get_token_amount",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "balance",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "spot_market",
+            "kind": "positional_or_keyword",
+            "type": "SpotMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "balance_type",
+            "kind": "positional_or_keyword",
+            "type": "SpotBalanceType",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(balance: int, spot_market: SpotMarketAccount, balance_type: SpotBalanceType) -> int"
+      },
+      {
+        "name": "get_token_value",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "amount",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "spot_decimals",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price_data",
+            "kind": "positional_or_keyword",
+            "type": "Union[OraclePriceData, int]",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(amount, spot_decimals, oracle_price_data: Union[OraclePriceData, int])"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.math.spot_position",
+    "path": "math/spot_position.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "calculate_weighted_token_value",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "token_amount",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "token_value",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "spot_market_account",
+            "kind": "positional_or_keyword",
+            "type": "SpotMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "margin_category",
+            "kind": "positional_or_keyword",
+            "type": "MarginCategory",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "custom_margin_ratio",
+            "kind": "positional_or_keyword",
+            "type": "Optional[float]",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "returns": {
+          "type": "(int, int)"
+        },
+        "signature": "(token_amount: int, token_value: int, oracle_price: int, spot_market_account: SpotMarketAccount, margin_category: MarginCategory, custom_margin_ratio: Optional[float] = None) -> (int, int)"
+      },
+      {
+        "name": "get_strict_token_value",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "token_amount",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "spot_decimals",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "strict_oracle_price",
+            "kind": "positional_or_keyword",
+            "type": "StrictOraclePrice",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(token_amount: int, spot_decimals: int, strict_oracle_price: StrictOraclePrice) -> int"
+      },
+      {
+        "name": "get_worst_case_token_amounts",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "spot_position",
+            "kind": "positional_or_keyword",
+            "type": "SpotPosition",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "spot_market_account",
+            "kind": "positional_or_keyword",
+            "type": "SpotMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "strict_oracle_price",
+            "kind": "positional_or_keyword",
+            "type": "StrictOraclePrice",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "margin_category",
+            "kind": "positional_or_keyword",
+            "type": "MarginCategory",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "custom_margin_ratio",
+            "kind": "positional_or_keyword",
+            "type": "Optional[float]",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "returns": {
+          "type": "OrderFillSimulation"
+        },
+        "signature": "(spot_position: SpotPosition, spot_market_account: SpotMarketAccount, strict_oracle_price: StrictOraclePrice, margin_category: MarginCategory, custom_margin_ratio: Optional[float] = None) -> OrderFillSimulation"
+      },
+      {
+        "name": "is_spot_position_available",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "position",
+            "kind": "positional_or_keyword",
+            "type": "SpotPosition",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(position: SpotPosition)"
+      },
+      {
+        "name": "simulate_order_fill",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "token_amount",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "token_value",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "open_orders",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "strict_oracle_price",
+            "kind": "positional_or_keyword",
+            "type": "StrictOraclePrice",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "spot_market",
+            "kind": "positional_or_keyword",
+            "type": "SpotMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "margin_category",
+            "kind": "positional_or_keyword",
+            "type": "MarginCategory",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "custom_margin_ratio",
+            "kind": "positional_or_keyword",
+            "type": "Optional[float]",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(token_amount: int, token_value: int, open_orders: int, strict_oracle_price: StrictOraclePrice, spot_market: SpotMarketAccount, margin_category: MarginCategory, custom_margin_ratio: Optional[float] = None)"
+      }
+    ],
+    "classes": [
+      {
+        "name": "OrderFillSimulation",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.math.user_status",
+    "path": "math/user_status.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "is_user_protected_maker",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "user_account",
+            "kind": "positional_or_keyword",
+            "type": "UserAccount",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(user_account: UserAccount) -> bool"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.math.utils",
+    "path": "math/utils.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "clamp_num",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "x",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "min_clamp",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "max_clamp",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(x: int, min_clamp: int, max_clamp: int) -> int"
+      },
+      {
+        "name": "div_ceil",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "a",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "b",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(a: int, b: int) -> int"
+      },
+      {
+        "name": "sig_num",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "x",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(x: int) -> int"
+      },
+      {
+        "name": "time_remaining_until_update",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "now",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "last_update_ts",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "update_period",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(now: int, last_update_ts: int, update_period: int) -> int"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.memcmp",
+    "path": "memcmp.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "get_market_type_filter",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market_type",
+            "kind": "positional_or_keyword",
+            "type": "MarketType",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "MemcmpOpts"
+        },
+        "signature": "(market_type: MarketType) -> MemcmpOpts"
+      },
+      {
+        "name": "get_non_idle_user_filter",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [],
+        "returns": {
+          "type": "MemcmpOpts"
+        },
+        "signature": "() -> MemcmpOpts"
+      },
+      {
+        "name": "get_signed_msg_user_orders_filter",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [],
+        "returns": {
+          "type": "MemcmpOpts"
+        },
+        "signature": "() -> MemcmpOpts"
+      },
+      {
+        "name": "get_user_filter",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [],
+        "returns": {
+          "type": "MemcmpOpts"
+        },
+        "signature": "() -> MemcmpOpts"
+      },
+      {
+        "name": "get_user_stats_filter",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [],
+        "returns": {
+          "type": "MemcmpOpts"
+        },
+        "signature": "() -> MemcmpOpts"
+      },
+      {
+        "name": "get_user_stats_is_referred_filter",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [],
+        "returns": {
+          "type": "MemcmpOpts"
+        },
+        "signature": "() -> MemcmpOpts"
+      },
+      {
+        "name": "get_user_stats_is_referred_or_referrer_filter",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [],
+        "returns": {
+          "type": "MemcmpOpts"
+        },
+        "signature": "() -> MemcmpOpts"
+      },
+      {
+        "name": "get_user_that_has_been_lp_filter",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [],
+        "returns": {
+          "type": "MemcmpOpts"
+        },
+        "signature": "() -> MemcmpOpts"
+      },
+      {
+        "name": "get_user_with_auction_filter",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [],
+        "returns": {
+          "type": "MemcmpOpts"
+        },
+        "signature": "() -> MemcmpOpts"
+      },
+      {
+        "name": "get_user_with_name_filter",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "name",
+            "kind": "positional_or_keyword",
+            "type": "str",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "MemcmpOpts"
+        },
+        "signature": "(name: str) -> MemcmpOpts"
+      },
+      {
+        "name": "get_user_with_order_filter",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [],
+        "returns": {
+          "type": "MemcmpOpts"
+        },
+        "signature": "() -> MemcmpOpts"
+      },
+      {
+        "name": "get_user_without_order_filter",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [],
+        "returns": {
+          "type": "MemcmpOpts"
+        },
+        "signature": "() -> MemcmpOpts"
+      },
+      {
+        "name": "get_users_with_pool_id_filter",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "pool_id",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "MemcmpOpts"
+        },
+        "signature": "(pool_id: int) -> MemcmpOpts"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.name",
+    "path": "name.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "MAX_LENGTH"
+      }
+    ],
+    "functions": [
+      {
+        "name": "encode_name",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "name",
+            "kind": "positional_or_keyword",
+            "type": "str",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "list[int]"
+        },
+        "signature": "(name: str) -> list[int]"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.oracles.oracle_id",
+    "path": "oracles/oracle_id.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "get_oracle_id",
+        "is_async": false,
+        "docstring": "Returns the oracle id for a given oracle and source",
+        "arguments": [
+          {
+            "name": "public_key",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "source",
+            "kind": "positional_or_keyword",
+            "type": "OracleSource",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "str"
+        },
+        "signature": "(public_key: Pubkey, source: OracleSource) -> str"
+      },
+      {
+        "name": "get_oracle_source_num",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "source",
+            "kind": "positional_or_keyword",
+            "type": "OracleSource",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(source: OracleSource) -> int"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.oracles.strict_oracle_price",
+    "path": "oracles/strict_oracle_price.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "StrictOraclePrice",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "current",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "twap",
+                "kind": "positional_or_keyword",
+                "type": "Optional[int]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, current: int, twap: Optional[int] = None)"
+          },
+          {
+            "name": "max",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self) -> int"
+          },
+          {
+            "name": "min",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.pickle.vat",
+    "path": "pickle/vat.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "Vat",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "drift_client",
+                "kind": "positional_or_keyword",
+                "type": "DriftClient",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "users",
+                "kind": "positional_or_keyword",
+                "type": "UserMap",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_stats",
+                "kind": "positional_or_keyword",
+                "type": "UserStatsMap",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_markets",
+                "kind": "positional_or_keyword",
+                "type": "MarketMap",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "perp_markets",
+                "kind": "positional_or_keyword",
+                "type": "MarketMap",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, drift_client: DriftClient, users: UserMap, user_stats: UserStatsMap, spot_markets: MarketMap, perp_markets: MarketMap)"
+          },
+          {
+            "name": "dump_oracles",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_filepath",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "perp_filepath",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_filepath: Optional[str] = None, perp_filepath: Optional[str] = None)"
+          },
+          {
+            "name": "get_filenames",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "prefix",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "dict[str, str]"
+            },
+            "signature": "(self, prefix: Optional[str]) -> dict[str, str]"
+          },
+          {
+            "name": "load_oracles",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_filename",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "perp_filename",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_filename: Optional[str] = None, perp_filename: Optional[str] = None)"
+          },
+          {
+            "name": "pickle",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "file_prefix",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "dict[str, str]"
+            },
+            "signature": "(self, file_prefix: Optional[str] = None) -> dict[str, str]"
+          },
+          {
+            "name": "register_oracle_slot",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unpickle",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "users_filename",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "user_stats_filename",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "spot_markets_filename",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "perp_markets_filename",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "spot_oracles_filename",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "perp_oracles_filename",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, users_filename: Optional[str] = None, user_stats_filename: Optional[str] = None, spot_markets_filename: Optional[str] = None, perp_markets_filename: Optional[str] = None, spot_oracles_filename: Optional[str] = None, perp_oracles_filename: Optional[str] = None)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.priority_fees.priority_fee_subscriber",
+    "path": "priority_fees/priority_fee_subscriber.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "PriorityFeeConfig",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "PriorityFeeSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "config",
+                "kind": "positional_or_keyword",
+                "type": "PriorityFeeConfig",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, config: PriorityFeeConfig)"
+          },
+          {
+            "name": "load",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "poll",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.setup.helpers",
+    "path": "setup/helpers.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "NATIVE_MINT"
+      }
+    ],
+    "functions": [
+      {
+        "name": "adjust_oracle_pretrade",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "baa",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "position_direction",
+            "kind": "positional_or_keyword",
+            "type": "PositionDirection",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "market",
+            "kind": "positional_or_keyword",
+            "type": "PerpMarketAccount",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(baa: int, position_direction: PositionDirection, market: PerpMarketAccount, oracle_program: Program)"
+      },
+      {
+        "name": "create_price_feed",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "oracle_program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "init_price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "confidence",
+            "kind": "positional_or_keyword",
+            "type": "Optional[int]",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "expo",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": false,
+            "default": "-4"
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(oracle_program: Program, init_price: int, confidence: Optional[int] = None, expo: int = -4) -> Pubkey"
+      },
+      {
+        "name": "get_feed_data",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "oracle_program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "price_feed",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "PriceData"
+        },
+        "signature": "(oracle_program: Program, price_feed: Pubkey) -> PriceData"
+      },
+      {
+        "name": "get_oracle_data",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "connection",
+            "kind": "positional_or_keyword",
+            "type": "AsyncClient",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_addr",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(connection: AsyncClient, oracle_addr: Pubkey)"
+      },
+      {
+        "name": "get_set_price_feed_detailed_ix",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "oracle_program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_public_key",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "price",
+            "kind": "positional_or_keyword",
+            "type": "float",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "conf",
+            "kind": "positional_or_keyword",
+            "type": "float",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "slot",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(oracle_program: Program, oracle_public_key: Pubkey, price: float, conf: float, slot: int)"
+      },
+      {
+        "name": "initialize_quote_spot_market",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "admin",
+            "kind": "positional_or_keyword",
+            "type": "Admin",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "usdc_mint",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(admin: Admin, usdc_mint: Pubkey)"
+      },
+      {
+        "name": "initialize_sol_spot_market",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "admin",
+            "kind": "positional_or_keyword",
+            "type": "Admin",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "sol_oracle",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "sol_mint",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": false,
+            "default": "NATIVE_MINT"
+          },
+          {
+            "name": "oracle_source",
+            "kind": "positional_or_keyword",
+            "type": "OracleSource",
+            "required": false,
+            "default": "OracleSource.Pyth()"
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(admin: Admin, sol_oracle: Pubkey, sol_mint: Pubkey = NATIVE_MINT, oracle_source: OracleSource = OracleSource.Pyth())"
+      },
+      {
+        "name": "mint_ix",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "usdc_mint",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "mint_auth",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "usdc_amount",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "ata_account",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Instruction"
+        },
+        "signature": "(usdc_mint: Pubkey, mint_auth: Pubkey, usdc_amount: int, ata_account: Pubkey) -> Instruction"
+      },
+      {
+        "name": "mock_oracle",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "pyth_program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "price",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": false,
+            "default": "int(50 * 100000000.0)"
+          },
+          {
+            "name": "expo",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": false,
+            "default": "-7"
+          }
+        ],
+        "returns": {
+          "type": "Pubkey"
+        },
+        "signature": "(pyth_program: Program, price: int = int(50 * 100000000.0), expo = -7) -> Pubkey"
+      },
+      {
+        "name": "parse_price_data",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "data",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "PriceData"
+        },
+        "signature": "(data: bytes) -> PriceData"
+      },
+      {
+        "name": "set_price_feed",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "oracle_program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_public_key",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "price",
+            "kind": "positional_or_keyword",
+            "type": "float",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(oracle_program: Program, oracle_public_key: Pubkey, price: float)"
+      },
+      {
+        "name": "set_price_feed_detailed",
+        "is_async": true,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "oracle_program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "oracle_public_key",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "price",
+            "kind": "positional_or_keyword",
+            "type": "float",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "conf",
+            "kind": "positional_or_keyword",
+            "type": "float",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "slot",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(oracle_program: Program, oracle_public_key: Pubkey, price: float, conf: float, slot: int)"
+      }
+    ],
+    "classes": [
+      {
+        "name": "PriceData",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.slot.slot_subscriber",
+    "path": "slot/slot_subscriber.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "SlotSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "drift_client",
+                "kind": "positional_or_keyword",
+                "type": "DriftClient",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, drift_client: DriftClient)"
+          },
+          {
+            "name": "get_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self) -> int"
+          },
+          {
+            "name": "on_slot_change",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot_info",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, slot_info: int)"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "subscribe_ws",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.swift.create_verify_ix",
+    "path": "swift/create_verify_ix.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "ED25519_INSTRUCTION_LAYOUT"
+      },
+      {
+        "name": "ED25519_INSTRUCTION_LEN"
+      },
+      {
+        "name": "MAGIC_LEN"
+      },
+      {
+        "name": "MESSAGE_SIZE_LEN"
+      },
+      {
+        "name": "PUBKEY_LEN"
+      },
+      {
+        "name": "SIGNATURE_LEN"
+      }
+    ],
+    "functions": [
+      {
+        "name": "create_minimal_ed25519_verify_ix",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "custom_instruction_index",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "message_offset",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "custom_instruction_data",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "magic_len",
+            "kind": "positional_or_keyword",
+            "type": "Optional[int]",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "returns": {
+          "type": "Instruction"
+        },
+        "signature": "(custom_instruction_index: int, message_offset: int, custom_instruction_data: bytes, magic_len: Optional[int] = None) -> Instruction"
+      },
+      {
+        "name": "get_ed25519_args_from_hex",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "hex_str",
+            "kind": "positional_or_keyword",
+            "type": "str",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "custom_instruction_index",
+            "kind": "positional_or_keyword",
+            "type": "Optional[int]",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "returns": {
+          "type": "Dict[str, bytes]"
+        },
+        "signature": "(hex_str: str, custom_instruction_index: Optional[int] = None) -> Dict[str, bytes]"
+      },
+      {
+        "name": "get_feed_id_uint8_array",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "feed_id",
+            "kind": "positional_or_keyword",
+            "type": "str",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bytes"
+        },
+        "signature": "(feed_id: str) -> bytes"
+      },
+      {
+        "name": "read_uint16_le",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "data",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "offset",
+            "kind": "positional_or_keyword",
+            "type": "int",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "int"
+        },
+        "signature": "(data: bytes, offset: int) -> int"
+      },
+      {
+        "name": "trim_feed_id",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "feed_id",
+            "kind": "positional_or_keyword",
+            "type": "str",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "str"
+        },
+        "signature": "(feed_id: str) -> str"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.swift.order_subscriber",
+    "path": "swift/order_subscriber.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "SIGNED_MSG_DELEGATE_DISCRIMINATOR"
+      },
+      {
+        "name": "SIGNED_MSG_STANDARD_DISCRIMINATOR"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "SwiftOrderSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "config",
+                "kind": "positional_or_keyword",
+                "type": "SwiftOrderSubscriberConfig",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, config: SwiftOrderSubscriberConfig)"
+          },
+          {
+            "name": "generate_challenge_response",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "nonce",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "str"
+            },
+            "signature": "(self, nonce: str) -> str"
+          },
+          {
+            "name": "get_place_and_make_signed_msg_order_ixs",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "order_message_raw",
+                "kind": "positional_or_keyword",
+                "type": "Dict",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "signed_msg_order_params_message",
+                "kind": "positional_or_keyword",
+                "type": "Union[SignedMsgOrderParamsMessage, SignedMsgOrderParamsDelegateMessage]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "maker_order_params",
+                "kind": "positional_or_keyword",
+                "type": "Dict",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, order_message_raw: Dict, signed_msg_order_params_message: Union[SignedMsgOrderParamsMessage, SignedMsgOrderParamsDelegateMessage], maker_order_params: Dict)"
+          },
+          {
+            "name": "get_symbol_for_market_index",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "market_index",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "str"
+            },
+            "signature": "(self, market_index: int) -> str"
+          },
+          {
+            "name": "handle_auth_message",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "message",
+                "kind": "positional_or_keyword",
+                "type": "Dict",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, message: Dict) -> None"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "on_order",
+                "kind": "positional_or_keyword",
+                "type": "Callable[[Dict, Union[SignedMsgOrderParamsMessage, SignedMsgOrderParamsDelegateMessage], bool], None]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "accept_sanitized",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "False"
+              },
+              {
+                "name": "accept_deposit_trades",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, on_order: Callable[[Dict, Union[SignedMsgOrderParamsMessage, SignedMsgOrderParamsDelegateMessage], bool], None], accept_sanitized: bool = False, accept_deposit_trades: bool = False) -> None"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      },
+      {
+        "name": "SwiftOrderSubscriberConfig",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.swift.util",
+    "path": "swift/util.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "digest_signature",
+        "is_async": false,
+        "docstring": "Create a SHA-256 hash of a signature and return it as a base64 string.\n\nArgs:\n    signature: The signature bytes to hash\n\nReturns:\n    Base64-encoded SHA-256 hash of the signature",
+        "arguments": [
+          {
+            "name": "signature",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "str"
+        },
+        "signature": "(signature: bytes) -> str"
+      },
+      {
+        "name": "generate_signed_msg_uuid",
+        "is_async": false,
+        "docstring": "Generate a random string similar to nanoid with specified length and convert to bytes.\n\nArgs:\n    length: Length of the random string to generate (default: 8)\n\nReturns:\n    Bytes representation of the generated random string",
+        "arguments": [
+          {
+            "name": "length",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": false,
+            "default": "8"
+          }
+        ],
+        "returns": {
+          "type": "bytes"
+        },
+        "signature": "(length = 8) -> bytes"
+      }
+    ],
+    "classes": []
+  },
+  {
+    "module": "driftpy.tx.fast_tx_sender",
+    "path": "tx/fast_tx_sender.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "FastTxSender",
+        "docstring": "The FastTxSender will refresh the latest blockhash in the background to save an RPC when building transactions.",
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "connection",
+                "kind": "positional_or_keyword",
+                "type": "AsyncClient",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "opts",
+                "kind": "positional_or_keyword",
+                "type": "TxOpts",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "blockhash_refresh_interval_secs",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "blockhash_commitment",
+                "kind": "positional_or_keyword",
+                "type": "Commitment",
+                "required": false,
+                "default": "Confirmed"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, connection: AsyncClient, opts: TxOpts, blockhash_refresh_interval_secs: int, blockhash_commitment: Commitment = Confirmed)"
+          },
+          {
+            "name": "fetch_latest_blockhash",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Hash"
+            },
+            "signature": "(self) -> Hash"
+          },
+          {
+            "name": "subscribe_blockhash",
+            "is_async": true,
+            "docstring": "Must be called with asyncio.create_task to prevent blocking",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.tx.jito_subscriber",
+    "path": "tx/jito_subscriber.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "JitoSubscriber",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "refresh_rate",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "kp",
+                "kind": "positional_or_keyword",
+                "type": "Keypair",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "connection",
+                "kind": "positional_or_keyword",
+                "type": "AsyncClient",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "block_engine_url",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, refresh_rate: int, kp: Keypair, connection: AsyncClient, block_engine_url: str)"
+          },
+          {
+            "name": "get_tip_ix",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "signer",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "tip_amount",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "1000000"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, signer: Pubkey, tip_amount: int = 1000000)"
+          },
+          {
+            "name": "process_bundle_result",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "uuid",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Tuple[bool, Union[int, str]]"
+            },
+            "signature": "(self, uuid: str) -> Tuple[bool, Union[int, str]]"
+          },
+          {
+            "name": "send_to_jito",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "current_slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self, current_slot: int) -> bool"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.tx.jito_tx_sender",
+    "path": "tx/jito_tx_sender.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "JitoTxSender",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "drift_client",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "opts",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "block_engine_url",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "jito_keypair",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "blockhash_commitment",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "blockhash_refresh_interval_secs",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "tip_amount",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, drift_client, opts, block_engine_url, jito_keypair, blockhash_commitment, blockhash_refresh_interval_secs = None, tip_amount = None)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.tx.standard_tx_sender",
+    "path": "tx/standard_tx_sender.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "StandardTxSender",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "connection",
+                "kind": "positional_or_keyword",
+                "type": "AsyncClient",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "opts",
+                "kind": "positional_or_keyword",
+                "type": "TxOpts",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "blockhash_commitment",
+                "kind": "positional_or_keyword",
+                "type": "Commitment",
+                "required": false,
+                "default": "Confirmed"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, connection: AsyncClient, opts: TxOpts, blockhash_commitment: Commitment = Confirmed)"
+          },
+          {
+            "name": "fetch_latest_blockhash",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Hash"
+            },
+            "signature": "(self) -> Hash"
+          },
+          {
+            "name": "get_blockhash",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Hash"
+            },
+            "signature": "(self) -> Hash"
+          },
+          {
+            "name": "get_versioned_tx",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "ixs",
+                "kind": "positional_or_keyword",
+                "type": "Sequence[Instruction]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "payer",
+                "kind": "positional_or_keyword",
+                "type": "Keypair",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "lookup_tables",
+                "kind": "positional_or_keyword",
+                "type": "Sequence[AddressLookupTableAccount]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "additional_signers",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Sequence[Keypair]]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "VersionedTransaction"
+            },
+            "signature": "(self, ixs: Sequence[Instruction], payer: Keypair, lookup_tables: Sequence[AddressLookupTableAccount], additional_signers: Optional[Sequence[Keypair]] = None) -> VersionedTransaction"
+          },
+          {
+            "name": "send",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "tx",
+                "kind": "positional_or_keyword",
+                "type": "VersionedTransaction",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "TxSigAndSlot"
+            },
+            "signature": "(self, tx: VersionedTransaction) -> TxSigAndSlot"
+          },
+          {
+            "name": "send_no_confirm",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "tx",
+                "kind": "positional_or_keyword",
+                "type": "VersionedTransaction",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "TxSigAndSlot"
+            },
+            "signature": "(self, tx: VersionedTransaction) -> TxSigAndSlot"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.tx.types",
+    "path": "tx/types.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "TxSender",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "get_versioned_tx",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "ixs",
+                "kind": "positional_or_keyword",
+                "type": "Sequence[Instruction]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "payer",
+                "kind": "positional_or_keyword",
+                "type": "Keypair",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "lookup_tables",
+                "kind": "positional_or_keyword",
+                "type": "Sequence[AddressLookupTableAccount]",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "additional_signers",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Sequence[Keypair]]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "VersionedTransaction"
+            },
+            "signature": "(self, ixs: Sequence[Instruction], payer: Keypair, lookup_tables: Sequence[AddressLookupTableAccount], additional_signers: Optional[Sequence[Keypair]]) -> VersionedTransaction"
+          },
+          {
+            "name": "send",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "tx",
+                "kind": "positional_or_keyword",
+                "type": "VersionedTransaction",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "TxSigAndSlot"
+            },
+            "signature": "(self, tx: VersionedTransaction) -> TxSigAndSlot"
+          }
+        ]
+      },
+      {
+        "name": "TxSigAndSlot",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.types",
+    "path": "types.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [
+      {
+        "name": "compress",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "data",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bytes"
+        },
+        "signature": "(data: bytes) -> bytes"
+      },
+      {
+        "name": "decompress",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "data",
+            "kind": "positional_or_keyword",
+            "type": "bytes",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bytes"
+        },
+        "signature": "(data: bytes) -> bytes"
+      },
+      {
+        "name": "get_ws_url",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "url",
+            "kind": "positional_or_keyword",
+            "type": "str",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "str"
+        },
+        "signature": "(url: str) -> str"
+      },
+      {
+        "name": "is_one_of_variant",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "enum",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "types",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(enum, types)"
+      },
+      {
+        "name": "is_variant",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "enum",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "_type",
+            "kind": "positional_or_keyword",
+            "type": "str",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(enum, _type: str) -> bool"
+      },
+      {
+        "name": "is_variant_str",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "enum",
+            "kind": "positional_or_keyword",
+            "type": null,
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "type",
+            "kind": "positional_or_keyword",
+            "type": "str",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "bool"
+        },
+        "signature": "(enum, type: str) -> bool"
+      },
+      {
+        "name": "market_type_to_string",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [
+          {
+            "name": "market_type",
+            "kind": "positional_or_keyword",
+            "type": "MarketType",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": null
+        },
+        "signature": "(market_type: MarketType)"
+      },
+      {
+        "name": "stack_trace",
+        "is_async": false,
+        "docstring": null,
+        "arguments": [],
+        "returns": {
+          "type": null
+        },
+        "signature": "()"
+      }
+    ],
+    "classes": [
+      {
+        "name": "AMM",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "AMMLiquiditySplit",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "AssetTier",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "AssetType",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "ContractTier",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "ContractType",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "CurveRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "DepositDirection",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "DepositExplanation",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "DepositRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "DriftAction",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "ExchangeStatus",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "FeeStructure",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "FeeTier",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "FillMode",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "FundingPaymentRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "FundingRateRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "GrpcConfig",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "GrpcLogProviderConfig",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "HistoricalIndexData",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "HistoricalOracleData",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "IfRebalanceConfigAccount",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "IfRebalanceConfigParams",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "InsuranceClaim",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "InsuranceFund",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "InsuranceFundRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "InsuranceFundStakeAccount",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "InsuranceFundStakeRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "InsuranceFundSwapRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "LPAction",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "LPRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "LiquidateBorrowForPerpPnlRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "LiquidatePerpPnlForDepositRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "LiquidatePerpRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "LiquidateSpotRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "LiquidationMultiplierType",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "LiquidationRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "LiquidationType",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "MMOraclePriceData",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "MakerInfo",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "MarginCalculationMode",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "MarginMode",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "MarginRequirementType",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "MarketIdentifier",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "MarketStatus",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "MarketType",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "ModifyOrderParams",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "ModifyOrderPolicy",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "NewUserRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "OptionalOrderParams",
+        "docstring": "All fields are optional except market_type, market_index, direction",
+        "methods": []
+      },
+      {
+        "name": "OracleGuardRails",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "OracleInfo",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "OraclePriceData",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "default",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [],
+            "returns": {
+              "type": null
+            },
+            "signature": "()"
+          }
+        ]
+      },
+      {
+        "name": "OracleSource",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "OracleSourceNum",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "OracleValidity",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "Order",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "OrderAction",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "OrderActionExplanation",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "OrderActionRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "OrderBitFlag",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "OrderFillerRewardStructure",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "OrderParams",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "check_market_type",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "set_perp",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "set_spot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      },
+      {
+        "name": "OrderParamsBitFlag",
+        "docstring": "Bit flags for OrderParams.bit_flags field",
+        "methods": [
+          {
+            "name": "is_immediate_or_cancel",
+            "is_async": false,
+            "docstring": "Check if IMMEDIATE_OR_CANCEL flag is set",
+            "arguments": [
+              {
+                "name": "bit_flags",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(bit_flags: int) -> bool"
+          },
+          {
+            "name": "is_update_high_leverage_mode",
+            "is_async": false,
+            "docstring": "Check if UPDATE_HIGH_LEVERAGE_MODE flag is set",
+            "arguments": [
+              {
+                "name": "bit_flags",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(bit_flags: int) -> bool"
+          }
+        ]
+      },
+      {
+        "name": "OrderRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "OrderStatus",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "OrderTriggerCondition",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "OrderType",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "PerpBankruptcyRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "PerpFulfillmentMethod",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "PerpMarketAccount",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "PerpPosition",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "PhoenixV1FulfillmentConfigAccount",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "PickledData",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "PoolBalance",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "PositionDirection",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "PositionUpdateType",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "PostOnlyParams",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "PrelaunchOracle",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "PrelaunchOracleParams",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "PriceDivergenceGuardRails",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "PriceFeedMessage",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "PriceUpdateV2",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "ProtocolIfSharesTransferConfigAccount",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "ReferrerInfo",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "ReferrerNameAccount",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SequenceAccount",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SerumV3FulfillmentConfigAccount",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SettlePnlExplanation",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SettlePnlRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SignedMsgOrderParams",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SignedMsgOrderParamsDelegateMessage",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SignedMsgOrderParamsMessage",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SignedMsgTriggerOrderParams",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SpotBalanceType",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SpotBankruptcyRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SpotFulfillmentConfigStatus",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SpotFulfillmentMethod",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SpotFulfillmentType",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SpotInterestRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SpotMarketAccount",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SpotPosition",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "StakeAction",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "StateAccount",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SwapDirection",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SwapRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SwapReduceOnly",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "TransferProtocolIfSharesToRevenuePoolRecord",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "TwapPeriod",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "TxParams",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "UserAccount",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "UserFees",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "UserStatsAccount",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "UserStatus",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "ValidityGuardRails",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.user_map.polling_sub",
+    "path": "user_map/polling_sub.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "PollingSubscription",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_map",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "frequency",
+                "kind": "positional_or_keyword",
+                "type": "float",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "skip_initial_load",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_map, frequency: float, skip_initial_load: bool = False)"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.user_map.referrer_map",
+    "path": "user_map/referrer_map.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "DEFAULT_PUBLIC_KEY"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "ReferrerMap",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "drift_client",
+                "kind": "positional_or_keyword",
+                "type": "DriftClient",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "parallel_sync",
+                "kind": "positional_or_keyword",
+                "type": "Optional[bool]",
+                "required": false,
+                "default": "True"
+              },
+              {
+                "name": "chunk_size",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "100"
+              },
+              {
+                "name": "max_concurrent_requests",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "5"
+              },
+              {
+                "name": "verbose",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, drift_client: DriftClient, parallel_sync: Optional[bool] = True, chunk_size: int = 100, max_concurrent_requests: int = 5, verbose: bool = False)"
+          },
+          {
+            "name": "add_referrer",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "authority",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "referrer",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, authority: str, referrer: Optional[str] = None)"
+          },
+          {
+            "name": "get",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "authority_public_key",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[ReferrerInfo]"
+            },
+            "signature": "(self, authority_public_key: str) -> Optional[ReferrerInfo]"
+          },
+          {
+            "name": "get_referrer",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "authority_public_key",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[ReferrerInfo]"
+            },
+            "signature": "(self, authority_public_key: str) -> Optional[ReferrerInfo]"
+          },
+          {
+            "name": "has",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "authority_public_key",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self, authority_public_key: str) -> bool"
+          },
+          {
+            "name": "log",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "message",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, message: str)"
+          },
+          {
+            "name": "must_get",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "authority_public_key",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[ReferrerInfo]"
+            },
+            "signature": "(self, authority_public_key: str) -> Optional[ReferrerInfo]"
+          },
+          {
+            "name": "number_of_referred",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self) -> int"
+          },
+          {
+            "name": "size",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self) -> int"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "sync",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self) -> None"
+          },
+          {
+            "name": "sync_all",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self) -> None"
+          },
+          {
+            "name": "sync_all_paged",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "semaphore",
+                "kind": "positional_or_keyword",
+                "type": "asyncio.Semaphore",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, semaphore: asyncio.Semaphore) -> None"
+          },
+          {
+            "name": "sync_referrer",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "referrer_filter",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, referrer_filter) -> None"
+          },
+          {
+            "name": "sync_referrer_paged",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "referrer_filter",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "semaphore",
+                "kind": "positional_or_keyword",
+                "type": "asyncio.Semaphore",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, referrer_filter, semaphore: asyncio.Semaphore) -> None"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self) -> None"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.user_map.types",
+    "path": "user_map/types.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "ConfigType",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "Subscription",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "UserMapInterface",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "add_pubkey",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account_public_key",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, user_account_public_key: Pubkey) -> None"
+          },
+          {
+            "name": "get",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "key",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DriftUser]"
+            },
+            "signature": "(self, key: str) -> Optional[DriftUser]"
+          },
+          {
+            "name": "get_user_authority",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "key",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[Pubkey]"
+            },
+            "signature": "(self, key: str) -> Optional[Pubkey]"
+          },
+          {
+            "name": "has",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "key",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self, key: str) -> bool"
+          },
+          {
+            "name": "must_get",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "key",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "DriftUser"
+            },
+            "signature": "(self, key: str) -> DriftUser"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self) -> None"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self) -> None"
+          },
+          {
+            "name": "values",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.user_map.user_map",
+    "path": "user_map/user_map.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "UserMap",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "config",
+                "kind": "positional_or_keyword",
+                "type": "UserMapConfig",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, config: UserMapConfig)"
+          },
+          {
+            "name": "add_pubkey",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account_public_key",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "data",
+                "kind": "positional_or_keyword",
+                "type": "Optional[DataAndSlot[UserAccount]]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self, user_account_public_key: Pubkey, data: Optional[DataAndSlot[UserAccount]] = None) -> None"
+          },
+          {
+            "name": "clear",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "dump",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "filename",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, filename: Optional[str] = None)"
+          },
+          {
+            "name": "get",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "key",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DriftUser]"
+            },
+            "signature": "(self, key: str) -> Optional[DriftUser]"
+          },
+          {
+            "name": "get_DLOB",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "slot",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, slot: int)"
+          },
+          {
+            "name": "get_last_dump_filepath",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "str"
+            },
+            "signature": "(self) -> str"
+          },
+          {
+            "name": "get_slot",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self) -> int"
+          },
+          {
+            "name": "get_user_authority",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_account_public_key",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[Pubkey]"
+            },
+            "signature": "(self, user_account_public_key: str) -> Optional[Pubkey]"
+          },
+          {
+            "name": "has",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "key",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self, key: str) -> bool"
+          },
+          {
+            "name": "load",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "filename",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, filename: Optional[str] = None)"
+          },
+          {
+            "name": "must_get",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "key",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "DriftUser"
+            },
+            "signature": "(self, key: str) -> DriftUser"
+          },
+          {
+            "name": "size",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "int"
+            },
+            "signature": "(self) -> int"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "sync",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self) -> None"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "None"
+            },
+            "signature": "(self) -> None"
+          },
+          {
+            "name": "update_user_account",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "key",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "data",
+                "kind": "positional_or_keyword",
+                "type": "DataAndSlot[UserAccount]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, key: str, data: DataAndSlot[UserAccount])"
+          },
+          {
+            "name": "update_with_order_record",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "record",
+                "kind": "positional_or_keyword",
+                "type": "OrderRecord",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, record: OrderRecord)"
+          },
+          {
+            "name": "values",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.user_map.user_map_config",
+    "path": "user_map/user_map_config.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "PollingConfig",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "SyncConfig",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "UserAccountFilterCriteria",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "UserMapConfig",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "UserStatsMapConfig",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "WebsocketConfig",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.user_map.userstats_map",
+    "path": "user_map/userstats_map.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "UserStatsMap",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "config",
+                "kind": "positional_or_keyword",
+                "type": "UserStatsMapConfig",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, config: UserStatsMapConfig)"
+          },
+          {
+            "name": "add_user_stat",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "authority",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_stats",
+                "kind": "positional_or_keyword",
+                "type": "Optional[DataAndSlot[UserStatsAccount]]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, authority: Pubkey, user_stats: Optional[DataAndSlot[UserStatsAccount]] = None)"
+          },
+          {
+            "name": "clear",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "default_sync",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "dump",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "filename",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, filename: Optional[str] = None)"
+          },
+          {
+            "name": "get",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "pubkey",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "Optional[DriftUserStats]"
+            },
+            "signature": "(self, pubkey: str) -> Optional[DriftUserStats]"
+          },
+          {
+            "name": "get_last_dump_filepath",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "str"
+            },
+            "signature": "(self) -> str"
+          },
+          {
+            "name": "has",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "pubkey",
+                "kind": "positional_or_keyword",
+                "type": "str",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": "bool"
+            },
+            "signature": "(self, pubkey: str) -> bool"
+          },
+          {
+            "name": "load",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "filename",
+                "kind": "positional_or_keyword",
+                "type": "Optional[str]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, filename: Optional[str] = None)"
+          },
+          {
+            "name": "must_get",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "pubkey",
+                "kind": "positional_or_keyword",
+                "type": "str | Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_stats",
+                "kind": "positional_or_keyword",
+                "type": "Optional[DataAndSlot[UserStatsAccount]]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": "DriftUserStats"
+            },
+            "signature": "(self, pubkey: str | Pubkey, user_stats: Optional[DataAndSlot[UserStatsAccount]] = None) -> DriftUserStats"
+          },
+          {
+            "name": "paginated_sync",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "size",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "sync",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "update_user_stat",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "authority",
+                "kind": "positional_or_keyword",
+                "type": "Pubkey",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_stats",
+                "kind": "positional_or_keyword",
+                "type": "DataAndSlot[UserStatsAccount]",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, authority: Pubkey, user_stats: DataAndSlot[UserStatsAccount])"
+          },
+          {
+            "name": "update_with_event_record",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "record",
+                "kind": "positional_or_keyword",
+                "type": "WrappedEvent",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_map",
+                "kind": "positional_or_keyword",
+                "type": "Optional[UserMap]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, record: WrappedEvent, user_map: Optional[UserMap] = None)"
+          },
+          {
+            "name": "update_with_order_record",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "record",
+                "kind": "positional_or_keyword",
+                "type": "OrderRecord",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_map",
+                "kind": "positional_or_keyword",
+                "type": "UserMap",
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, record: OrderRecord, user_map: UserMap)"
+          },
+          {
+            "name": "values",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.user_map.websocket_sub",
+    "path": "user_map/websocket_sub.py",
+    "docstring": null,
+    "constants": [
+      {
+        "name": "T"
+      }
+    ],
+    "functions": [],
+    "classes": [
+      {
+        "name": "WebsocketSubscription",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "user_map",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "commitment",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "on_update",
+                "kind": "positional_or_keyword",
+                "type": "UpdateCallback",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "skip_initial_load",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "False"
+              },
+              {
+                "name": "resub_timeout_ms",
+                "kind": "positional_or_keyword",
+                "type": "int",
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "include_idle",
+                "kind": "positional_or_keyword",
+                "type": "bool",
+                "required": false,
+                "default": "False"
+              },
+              {
+                "name": "decode",
+                "kind": "positional_or_keyword",
+                "type": "Optional[Callable[[bytes], T]]",
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, user_map, commitment, on_update: UpdateCallback, skip_initial_load: bool = False, resub_timeout_ms: int = None, include_idle: bool = False, decode: Optional[Callable[[bytes], T]] = None)"
+          },
+          {
+            "name": "subscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "unsubscribe",
+            "is_async": true,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "module": "driftpy.vaults.helpers",
+    "path": "vaults/helpers.py",
+    "docstring": "Helper functions for interacting with the Drift Vaults program.\n\nThis module provides utilities for querying vault information, depositors,\nand other vault-related data.\n\nPython functions provided here are for basic usage.\nFor a complete vaults SDK, please see https://github.com/drift-labs/drift-vaults",
+    "constants": [],
+    "functions": [
+      {
+        "name": "fetch_all_vault_depositors",
+        "is_async": true,
+        "docstring": "Fetch all vault depositors from the program\n\nArgs:\n    program: The vaults program\n\nReturns:\n    Dictionary with 'regular' and 'tokenized' depositor lists",
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "DepositorData"
+        },
+        "signature": "(program: Program) -> DepositorData"
+      },
+      {
+        "name": "filter_vault_depositors",
+        "is_async": true,
+        "docstring": "Filter depositors for a specific vault from pre-fetched depositor data\n\nArgs:\n    depositors_data: Dictionary with 'regular' and 'tokenized' depositor lists\n    vault_pubkey: The public key of the vault (can be string or Pubkey)\n\nReturns:\n    List of vault depositor accounts for the specified vault",
+        "arguments": [
+          {
+            "name": "depositors_data",
+            "kind": "positional_or_keyword",
+            "type": "List[VaultDepositor]",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "vault_pubkey",
+            "kind": "positional_or_keyword",
+            "type": "str | Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "DepositorList"
+        },
+        "signature": "(depositors_data: List[VaultDepositor], vault_pubkey: str | Pubkey) -> DepositorList"
+      },
+      {
+        "name": "get_all_vaults",
+        "is_async": true,
+        "docstring": "Get all vaults from the program\n\nArgs:\n    program: The vaults program\n\nReturns:\n    List of vault accounts with their data",
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "List[Dict[str, Any]]"
+        },
+        "signature": "(program: Program) -> List[Dict[str, Any]]"
+      },
+      {
+        "name": "get_depositor_info",
+        "is_async": true,
+        "docstring": "Get detailed information about a specific depositor in a vault\n\nArgs:\n    program: The vaults program\n    vault_pubkey: The public key of the vault\n    depositor_pubkey: The public key of the depositor\n\nReturns:\n    Dictionary with depositor information if found, None otherwise",
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "vault_pubkey",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "depositor_pubkey",
+            "kind": "positional_or_keyword",
+            "type": "Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Optional[Dict[str, Any]]"
+        },
+        "signature": "(program: Program, vault_pubkey: Pubkey, depositor_pubkey: Pubkey) -> Optional[Dict[str, Any]]"
+      },
+      {
+        "name": "get_vault_by_name",
+        "is_async": true,
+        "docstring": "Get a vault by its name\n\nArgs:\n    program: The vaults program\n    name: The name of the vault\n    case_sensitive: Whether to match the vault name case-sensitively\n\nReturns:\n    The vault account with its data if found, None otherwise",
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "name",
+            "kind": "positional_or_keyword",
+            "type": "str",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "case_sensitive",
+            "kind": "positional_or_keyword",
+            "type": "bool",
+            "required": false,
+            "default": "False"
+          }
+        ],
+        "returns": {
+          "type": "Optional[Dict[str, Any]]"
+        },
+        "signature": "(program: Program, name: str, case_sensitive: bool = False) -> Optional[Dict[str, Any]]"
+      },
+      {
+        "name": "get_vault_depositors",
+        "is_async": true,
+        "docstring": "Get all depositors for a specific vault\n\nArgs:\n    program: The vaults program\n    vault_pubkey: The public key of the vault (can be string or Pubkey)\n\nReturns:\n    List of vault depositor accounts with their data",
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "vault_pubkey",
+            "kind": "positional_or_keyword",
+            "type": "str | Pubkey",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "DepositorList"
+        },
+        "signature": "(program: Program, vault_pubkey: str | Pubkey) -> DepositorList"
+      },
+      {
+        "name": "get_vault_stats",
+        "is_async": true,
+        "docstring": "Get detailed statistics for a vault including total deposits, shares, etc.\n\nArgs:\n    program: The vaults program\n    vault_pubkeys: The public keys of the vaults\n    include_depositors: Whether to include depositors in the stats\n\nReturns:\n    Dictionary with vault statistics",
+        "arguments": [
+          {
+            "name": "program",
+            "kind": "positional_or_keyword",
+            "type": "Program",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "vault_pubkeys",
+            "kind": "positional_or_keyword",
+            "type": "List[Pubkey]",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "include_depositors",
+            "kind": "positional_or_keyword",
+            "type": "bool",
+            "required": false,
+            "default": "False"
+          }
+        ],
+        "returns": {
+          "type": "Dict[str, Any]"
+        },
+        "signature": "(program: Program, vault_pubkeys: List[Pubkey], include_depositors: bool = False) -> Dict[str, Any]"
+      },
+      {
+        "name": "get_vaults_program",
+        "is_async": true,
+        "docstring": "Get the vaults program as an anchorpy Program object",
+        "arguments": [
+          {
+            "name": "connection",
+            "kind": "positional_or_keyword",
+            "type": "AsyncClient",
+            "required": true,
+            "default": null
+          }
+        ],
+        "returns": {
+          "type": "Program"
+        },
+        "signature": "(connection: AsyncClient) -> Program"
+      }
+    ],
+    "classes": [
+      {
+        "name": "TokenizedVaultDepositor",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "VaultDepositor",
+        "docstring": null,
+        "methods": []
+      },
+      {
+        "name": "WithdrawRequest",
+        "docstring": null,
+        "methods": []
+      }
+    ]
+  },
+  {
+    "module": "driftpy.vaults.vault_client",
+    "path": "vaults/vault_client.py",
+    "docstring": null,
+    "constants": [],
+    "functions": [],
+    "classes": [
+      {
+        "name": "VaultClient",
+        "docstring": null,
+        "methods": [
+          {
+            "name": "__init__",
+            "is_async": false,
+            "docstring": null,
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "connection",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "wallet",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "None"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, connection, wallet = None)"
+          },
+          {
+            "name": "calculate_analytics",
+            "is_async": true,
+            "docstring": "Calculate common analytics metrics for vaults",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "vault_pubkey",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "refresh",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, vault_pubkey = None, refresh = False)"
+          },
+          {
+            "name": "drift_client",
+            "is_async": true,
+            "docstring": "Lazy-loaded drift client",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "get_all_depositors",
+            "is_async": true,
+            "docstring": "Get all depositors with optional cache refresh",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "refresh",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, refresh = False)"
+          },
+          {
+            "name": "get_all_vaults",
+            "is_async": true,
+            "docstring": "Get all vaults with optional cache refresh",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "refresh",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, refresh = False)"
+          },
+          {
+            "name": "get_spot_market_decimals_and_price",
+            "is_async": true,
+            "docstring": "Get decimals for a spot market with caching",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "spot_market_index",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, spot_market_index)"
+          },
+          {
+            "name": "get_vault_by_name",
+            "is_async": true,
+            "docstring": "Find a vault by name using cached data",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "name",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "case_sensitive",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "False"
+              },
+              {
+                "name": "refresh",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, name, case_sensitive = False, refresh = False)"
+          },
+          {
+            "name": "get_vault_depositors",
+            "is_async": true,
+            "docstring": "Get depositors for a specific vault using cached data",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "vault_pubkey",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "refresh",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, vault_pubkey, refresh = False)"
+          },
+          {
+            "name": "get_vault_depositors_with_stats",
+            "is_async": true,
+            "docstring": "Get depositors with additional stats using cached data",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "vault_pubkey",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "refresh",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, vault_pubkey, refresh = False)"
+          },
+          {
+            "name": "get_vault_stats",
+            "is_async": true,
+            "docstring": "Get stats for vaults (with optional cache refresh)",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "vault_pubkeys",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "None"
+              },
+              {
+                "name": "include_depositors",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "False"
+              },
+              {
+                "name": "normalize_amounts",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "True"
+              },
+              {
+                "name": "refresh",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, vault_pubkeys = None, include_depositors = False, normalize_amounts = True, refresh = False)"
+          },
+          {
+            "name": "initialize",
+            "is_async": true,
+            "docstring": "Initialize the vault client",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self)"
+          },
+          {
+            "name": "refresh_cache",
+            "is_async": true,
+            "docstring": "Refresh all cached data",
+            "arguments": [
+              {
+                "name": "self",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "force",
+                "kind": "positional_or_keyword",
+                "type": null,
+                "required": false,
+                "default": "False"
+              }
+            ],
+            "returns": {
+              "type": null
+            },
+            "signature": "(self, force = False)"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/scripts/export_api_docs.py
+++ b/scripts/export_api_docs.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Export public API docs for driftpy modules to JSON.
+
+This script parses source files with ``ast`` (no imports) and emits an API
+inventory focused on public classes, methods, functions, and constants.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SKIP_SUFFIXES = ("_pb2.py", "_pb2_grpc.py")
+
+
+@dataclass
+class ParameterDoc:
+    name: str
+    kind: str
+    annotation: str | None
+    required: bool
+    default: str | None
+
+
+@dataclass
+class ReturnDoc:
+    annotation: str | None
+
+
+@dataclass
+class SymbolDoc:
+    name: str
+    is_async: bool
+    docstring: str | None
+    arguments: list[ParameterDoc]
+    returns: ReturnDoc
+
+
+@dataclass
+class ConstantDoc:
+    name: str
+
+
+@dataclass
+class ClassDoc:
+    name: str
+    docstring: str | None
+    methods: list[SymbolDoc]
+
+
+@dataclass
+class ModuleDoc:
+    module: str
+    path: str
+    docstring: str | None
+    constants: list[ConstantDoc]
+    functions: list[SymbolDoc]
+    classes: list[ClassDoc]
+
+
+def is_public(name: str) -> bool:
+    return not name.startswith("_")
+
+
+def keep_method(name: str) -> bool:
+    return name == "__init__" or is_public(name)
+
+
+def clean_doc(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def annotation_to_str(annotation: ast.AST | None) -> str | None:
+    if annotation is None:
+        return None
+    return ast.unparse(annotation)
+
+
+def expr_to_str(expr: ast.AST | None) -> str | None:
+    if expr is None:
+        return None
+    return ast.unparse(expr)
+
+
+def render_signature(arguments: list[ParameterDoc], returns: ReturnDoc) -> str:
+    parts: list[str] = []
+
+    for param in arguments:
+        if param.kind == "positional_only_separator":
+            parts.append("/")
+            continue
+        if param.kind == "keyword_only_separator":
+            parts.append("*")
+            continue
+
+        name = param.name
+        if param.kind == "var_positional":
+            name = f"*{name}"
+        elif param.kind == "var_keyword":
+            name = f"**{name}"
+
+        text = name
+        if param.annotation:
+            text += f": {param.annotation}"
+        if param.default is not None:
+            text += f" = {param.default}"
+
+        parts.append(text)
+
+    rendered = f"({', '.join(parts)})"
+    if returns.annotation:
+        return f"{rendered} -> {returns.annotation}"
+    return rendered
+
+
+def extract_parameters(args: ast.arguments) -> list[ParameterDoc]:
+    params: list[ParameterDoc] = []
+
+    posonly = list(args.posonlyargs)
+    normal = list(args.args)
+    defaults = list(args.defaults)
+
+    total_positional = len(posonly) + len(normal)
+    defaults_start = total_positional - len(defaults)
+
+    index = 0
+    for arg in posonly + normal:
+        default = None
+        if index >= defaults_start:
+            default = expr_to_str(defaults[index - defaults_start])
+
+        params.append(
+            ParameterDoc(
+                name=arg.arg,
+                kind="positional_only" if index < len(posonly) else "positional_or_keyword",
+                annotation=annotation_to_str(arg.annotation),
+                required=default is None,
+                default=default,
+            )
+        )
+        index += 1
+
+    if posonly:
+        params.append(
+            ParameterDoc(
+                name="/",
+                kind="positional_only_separator",
+                annotation=None,
+                required=False,
+                default=None,
+            )
+        )
+
+    if args.vararg:
+        params.append(
+            ParameterDoc(
+                name=args.vararg.arg,
+                kind="var_positional",
+                annotation=annotation_to_str(args.vararg.annotation),
+                required=False,
+                default=None,
+            )
+        )
+    elif args.kwonlyargs:
+        params.append(
+            ParameterDoc(
+                name="*",
+                kind="keyword_only_separator",
+                annotation=None,
+                required=False,
+                default=None,
+            )
+        )
+
+    for kw_arg, kw_default in zip(args.kwonlyargs, args.kw_defaults):
+        default = expr_to_str(kw_default) if kw_default is not None else None
+        params.append(
+            ParameterDoc(
+                name=kw_arg.arg,
+                kind="keyword_only",
+                annotation=annotation_to_str(kw_arg.annotation),
+                required=kw_default is None,
+                default=default,
+            )
+        )
+
+    if args.kwarg:
+        params.append(
+            ParameterDoc(
+                name=args.kwarg.arg,
+                kind="var_keyword",
+                annotation=annotation_to_str(args.kwarg.annotation),
+                required=False,
+                default=None,
+            )
+        )
+
+    return params
+
+
+def extract_symbol(node: ast.FunctionDef | ast.AsyncFunctionDef) -> SymbolDoc:
+    arguments = extract_parameters(node.args)
+    returns = ReturnDoc(annotation=annotation_to_str(node.returns))
+    return SymbolDoc(
+        name=node.name,
+        is_async=isinstance(node, ast.AsyncFunctionDef),
+        docstring=clean_doc(ast.get_docstring(node)),
+        arguments=arguments,
+        returns=returns,
+    )
+
+
+def extract_constant_names(node: ast.Assign | ast.AnnAssign) -> list[str]:
+    names: list[str] = []
+
+    targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+
+    for target in targets:
+        if isinstance(target, ast.Name) and target.id.isupper():
+            names.append(target.id)
+
+    return names
+
+
+def parse_module(file_path: Path, package_root: Path, module_prefix: str) -> ModuleDoc | None:
+    source = file_path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+
+    relative = file_path.relative_to(package_root)
+    module_parts = list(relative.with_suffix("").parts)
+    if module_parts and module_parts[-1] == "__init__":
+        module_parts = module_parts[:-1]
+    module_name = ".".join([module_prefix] + module_parts) if module_parts else module_prefix
+
+    module_doc = clean_doc(ast.get_docstring(tree))
+
+    constants: dict[str, ConstantDoc] = {}
+    functions: list[SymbolDoc] = []
+    classes: list[ClassDoc] = []
+
+    for node in tree.body:
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            for constant_name in extract_constant_names(node):
+                constants.setdefault(constant_name, ConstantDoc(name=constant_name))
+
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and is_public(node.name):
+            functions.append(extract_symbol(node))
+
+        if isinstance(node, ast.ClassDef) and is_public(node.name):
+            methods: list[SymbolDoc] = []
+            for class_node in node.body:
+                if isinstance(class_node, (ast.FunctionDef, ast.AsyncFunctionDef)) and keep_method(
+                    class_node.name
+                ):
+                    methods.append(extract_symbol(class_node))
+
+            classes.append(
+                ClassDoc(
+                    name=node.name,
+                    docstring=clean_doc(ast.get_docstring(node)),
+                    methods=sorted(methods, key=lambda x: x.name),
+                )
+            )
+
+    if not (constants or functions or classes):
+        return None
+
+    return ModuleDoc(
+        module=module_name,
+        path=str(relative),
+        docstring=module_doc,
+        constants=sorted(constants.values(), key=lambda x: x.name),
+        functions=sorted(functions, key=lambda x: x.name),
+        classes=sorted(classes, key=lambda x: x.name),
+    )
+
+
+def collect_modules(package_root: Path, module_prefix: str) -> list[ModuleDoc]:
+    modules: list[ModuleDoc] = []
+    for file_path in sorted(package_root.rglob("*.py")):
+        if any(part.startswith(".") for part in file_path.parts):
+            continue
+        if file_path.name.startswith("test_"):
+            continue
+        if file_path.name.endswith(SKIP_SUFFIXES):
+            continue
+
+        parsed = parse_module(file_path, package_root, module_prefix)
+        if parsed is not None:
+            modules.append(parsed)
+
+    return sorted(modules, key=lambda x: x.module)
+
+
+def parameter_to_jsonable(parameter: ParameterDoc) -> dict[str, Any]:
+    return {
+        "name": parameter.name,
+        "kind": parameter.kind,
+        "type": parameter.annotation,
+        "required": parameter.required,
+        "default": parameter.default,
+    }
+
+
+def symbol_to_jsonable(symbol: SymbolDoc) -> dict[str, Any]:
+    return {
+        "name": symbol.name,
+        "is_async": symbol.is_async,
+        "docstring": symbol.docstring,
+        "arguments": [parameter_to_jsonable(param) for param in symbol.arguments],
+        "returns": {
+            "type": symbol.returns.annotation,
+        },
+        "signature": render_signature(symbol.arguments, symbol.returns),
+    }
+
+
+def to_jsonable(modules: list[ModuleDoc]) -> list[dict[str, Any]]:
+    payload: list[dict[str, Any]] = []
+    for module in modules:
+        payload.append(
+            {
+                "module": module.module,
+                "path": module.path,
+                "docstring": module.docstring,
+                "constants": [{"name": constant.name} for constant in module.constants],
+                "functions": [symbol_to_jsonable(function) for function in module.functions],
+                "classes": [
+                    {
+                        "name": class_doc.name,
+                        "docstring": class_doc.docstring,
+                        "methods": [symbol_to_jsonable(method) for method in class_doc.methods],
+                    }
+                    for class_doc in module.classes
+                ],
+            }
+        )
+    return payload
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export driftpy API docs to JSON")
+    parser.add_argument("--package-root", default="src/driftpy", help="Root directory of package source")
+    parser.add_argument("--module-prefix", default="driftpy", help="Python module prefix")
+    parser.add_argument(
+        "--output-json",
+        default="docs/generated/api_reference.json",
+        help="Output path for JSON export",
+    )
+    args = parser.parse_args()
+
+    package_root = Path(args.package_root)
+    output_json = Path(args.output_json)
+
+    modules = collect_modules(package_root=package_root, module_prefix=args.module_prefix)
+
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(json.dumps(to_jsonable(modules), indent=2), encoding="utf-8")
+
+    print(f"Exported {len(modules)} modules")
+    print(f"- JSON: {output_json}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is for use in our docs.drift.trade. Just need to run:
```/usr/bin/python3 scripts/export_api_docs.py```

If there's a better way to do this lmk. Seems like mkdocs doesn't really have any other export options.