### PR TITLE
ci: pin GitHub Actions to commit SHAs (FE-4376)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.5.0
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
 
       - name: Set up Python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
         with:
           python-version: '3.10' 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,13 +15,13 @@ jobs:
   tests:
     runs-on: ubicloud
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.10.10"
       - name: Install and configure Poetry
-        uses: snok/install-poetry@v1.3.3
+        uses: snok/install-poetry@d45b6d76012debf457ab49dffc7fb7b2efe8071d # v1.3.3
         with:
           version: 1.4.2
           virtualenvs-create: true
@@ -45,11 +45,11 @@ jobs:
     needs: [tests]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.10.10"
       - name: Run version bump script
@@ -61,7 +61,7 @@ jobs:
           git add pyproject.toml src/driftpy/__init__.py .bumpversion.cfg
           git commit -m "Bump version [skip ci]"
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
@@ -72,7 +72,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
       - name: Pull Latest Changes
@@ -81,11 +81,11 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git pull
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.10.10"
       - name: Install and configure Poetry
-        uses: snok/install-poetry@v1.3.3
+        uses: snok/install-poetry@d45b6d76012debf457ab49dffc7fb7b2efe8071d # v1.3.3
         with:
           version: 1.4.2
           virtualenvs-create: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,17 +7,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2.5.0
+      uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
 
     - name: Set up Python
-      uses: actions/setup-python@v4.3.0
+      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
       with:
         python-version: '3.10.10' 
     #----------------------------------------------
     #  -----  install & configure poetry  -----
     #----------------------------------------------
     - name: Install and configure Poetry
-      uses: snok/install-poetry@v1.3.3
+      uses: snok/install-poetry@d45b6d76012debf457ab49dffc7fb7b2efe8071d # v1.3.3
       with:
         version: 1.4.2
         virtualenvs-create: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo.
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           submodules: 'recursive'
 
       - name: Cache Solana Tool Suite
-        uses: actions/cache@v2
+        uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         id: cache-solana
         with:
           path: |
@@ -28,7 +28,7 @@ jobs:
           key: solana-${{ runner.os }}-v0000-${{ env.solana_verion }}
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           profile: minimal
           toolchain: nightly
@@ -41,7 +41,7 @@ jobs:
       - name: Add Solana to path
         run: echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: '17'
 
@@ -52,7 +52,7 @@ jobs:
         run: yes | solana-keygen new
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@0f07f7f756721ebd886c2462646a35f78a8bc4de # v1
         with:
           python-version: 3.9
 
@@ -60,7 +60,7 @@ jobs:
       #  -----  install & configure poetry  -----
       #----------------------------------------------
       - name: Install and configure Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
         with:
           version: 1.1.10
           virtualenvs-create: true
@@ -71,7 +71,7 @@ jobs:
       #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
## What

Pin all floating GitHub Actions refs in this repo to full commit SHAs (with `# version` comments), across workflow files and composite `action.yml` files. SHAs are the exact commits each tag/branch currently resolves to.

## Why

Part of the org-wide GitHub Actions hardening effort ([FE-4376](https://linear.app/driftprotocol/issue/FE-4376/improve-github-actions-security)). The `drift-labs` org now has `sha_pinning_required: true` and is moving off `Allow all actions` to a selected-actions allow-list. Floating refs (`@v1`, `@master`, …) must be pinned to full SHAs first so neither the pin-enforcement policy nor the allow-list flip breaks CI. Pinning to a SHA is the actual supply-chain defense (a mutable `@master`/tag can be moved by a compromised maintainer).

## Scope

Action ref pins only — no logic changes. Behavior preserved (e.g. `dtolnay/rust-toolchain@stable` pins to the stable-branch commit whose `action.yml` still defaults to the stable channel).