### PR TITLE
chore: rename drift-labs GitHub URLs to velocity-exchange

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,9 +9,9 @@ markdown_extensions:
   - meta
   - pymdownx.tabbed:
       alternate_style: true
-repo_url: https://github.com/drift-labs/driftpy
-repo_name: drift-labs/driftpy
-site_url: https://drift-labs.github.io/driftpy/
+repo_url: https://github.com/velocity-exchange/driftpy
+repo_name: velocity-exchange/driftpy
+site_url: https://velocity-exchange.github.io/driftpy/
 plugins:
   - mkdocstrings:
       handlers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ authors = [
 ]
 license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/drift-labs/driftpy"
-documentation = "https://drift-labs.github.io/driftpy/"
+homepage = "https://github.com/velocity-exchange/driftpy"
+documentation = "https://velocity-exchange.github.io/driftpy/"
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/src/driftpy/vaults/__init__.py
+++ b/src/driftpy/vaults/__init__.py
@@ -1,7 +1,7 @@
 """
 Some simple helpers for interacting with the vaults program.
 
-For a complete vaults SDK, please see https://github.com/drift-labs/drift-vaults
+For a complete vaults SDK, please see https://github.com/velocity-exchange/drift-vaults
 """
 
 from driftpy.vaults.helpers import (

--- a/src/driftpy/vaults/helpers.py
+++ b/src/driftpy/vaults/helpers.py
@@ -5,7 +5,7 @@ This module provides utilities for querying vault information, depositors,
 and other vault-related data.
 
 Python functions provided here are for basic usage.
-For a complete vaults SDK, please see https://github.com/drift-labs/drift-vaults
+For a complete vaults SDK, please see https://github.com/velocity-exchange/drift-vaults
 """
 
 from pathlib import Path


### PR DESCRIPTION
Part of renaming the GitHub org drift-labs -> velocity-exchange.

**DRAFT — do not merge until the velocity-exchange org (and, where applicable, the @velocity-exchange npm scope) exists; old URLs currently redirect.**

## URL forms changed

- `github.com/drift-labs/` → `github.com/velocity-exchange/` (3 occurrences: mkdocs.yml repo_url, pyproject.toml homepage, vaults SDK reference links)
- `drift-labs.github.io` → `velocity-exchange.github.io` (2 occurrences: mkdocs.yml site_url, pyproject.toml documentation)

**Total substitutions: 7 across 4 files**

## Files changed

- `mkdocs.yml` — repo_url, repo_name, site_url
- `pyproject.toml` — homepage, documentation URLs
- `src/driftpy/vaults/__init__.py` — drift-vaults repo reference in docstring
- `src/driftpy/vaults/helpers.py` — drift-vaults repo reference in docstring

## Skipped (upstream-Drift historical refs)

- `.gitmodules:3` — submodule URL `https://github.com/drift-labs/protocol-v2.git`: this is the fork-origin upstream submodule pointing to the original Drift protocol-v2 repository; left as-is to preserve the upstream reference.
- `README.md:10` — link `https://drift-labs.github.io/v2-teacher/`: this points to the Drift Labs upstream documentation site ("v2-teacher"), which is a separate Drift project resource, not this repo's own docs site.

## Notes

No `@drift-labs/*` npm-scope deps or imports were present in this Python repository — no npm scope warning applies.